### PR TITLE
Create client-side app header navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import AppHeader from "@/components/layout/AppHeader";
 import Link from "next/link";
 import type { Metadata } from "next";
 import "./globals.css";
@@ -18,36 +19,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="font-sans bg-[var(--background)] text-[var(--foreground)] antialiased">
         <div className="flex min-h-screen flex-col">
-          <header className="border-b border-black/10 bg-white/80 px-4 py-4 backdrop-blur-sm dark:border-white/10 dark:bg-neutral-900/80">
-            <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-6">
-              <Link
-                className="text-lg font-semibold tracking-tight text-black transition hover:text-black/70 dark:text-white dark:hover:text-white/80"
-                href="/"
-              >
-                Meblomat
-              </Link>
-              <nav className="flex items-center gap-3 text-sm font-medium text-black/70 dark:text-white/70">
-                <Link
-                  className="rounded-full px-3 py-1 transition hover:bg-black/5 dark:hover:bg-white/10"
-                  href="/auth/login"
-                >
-                  Login
-                </Link>
-                <Link
-                  className="rounded-full px-3 py-1 transition hover:bg-black/5 dark:hover:bg-white/10"
-                  href="/auth/register"
-                >
-                  Register
-                </Link>
-                <Link
-                  className="rounded-full px-3 py-1 transition hover:bg-black/5 dark:hover:bg-white/10"
-                  href="/dashboard"
-                >
-                  Dashboard
-                </Link>
-              </nav>
-            </div>
-          </header>
+          <AppHeader />
           <main className="flex flex-1 flex-col">{children}</main>
           <footer className="border-t border-black/10 bg-white/80 px-4 py-6 text-sm text-black/60 dark:border-white/10 dark:bg-neutral-900/80 dark:text-white/60">
             <div className="mx-auto flex w-full max-w-5xl items-center justify-between">

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+
+const navigationLinks = [
+  { href: "/#meble", label: "meble" },
+  { href: "/#pomieszczenie", label: "pomieszczenie" },
+  { href: "/#wycena", label: "wycena" },
+  { href: "/#formatki", label: "formatki" },
+  { href: "/play", label: "play", withIcon: true },
+] as const;
+
+export default function AppHeader() {
+  return (
+    <header className="border-b border-black/10 bg-white/80 px-4 py-4 backdrop-blur-sm dark:border-white/10 dark:bg-neutral-900/80">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-6">
+        <div className="flex items-center gap-6">
+          <Link
+            className="text-lg font-semibold tracking-tight text-black transition hover:text-black/70 dark:text-white dark:hover:text-white/80"
+            href="/"
+          >
+            Meblomat
+          </Link>
+          <nav className="flex items-center gap-3 text-sm font-medium text-black/70 dark:text-white/70">
+            {navigationLinks.map((item) => (
+              <Link
+                key={item.label}
+                className="rounded-full px-3 py-1 capitalize transition hover:bg-black/5 hover:text-black dark:hover:bg-white/10 dark:hover:text-white"
+                href={item.href}
+              >
+                <span className="flex items-center gap-1">
+                  {item.label}
+                  {item.withIcon ? (
+                    <span aria-hidden="true" className="text-xs">
+                      ▶
+                    </span>
+                  ) : null}
+                </span>
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="flex items-center gap-3 text-sm font-medium">
+          <Link
+            className="rounded-full px-4 py-2 text-black transition hover:bg-black/5 dark:text-white dark:hover:bg-white/10"
+            href="/auth/login"
+          >
+            Zaloguj się
+          </Link>
+          <Link
+            className="rounded-full bg-black px-4 py-2 text-white shadow-sm transition hover:bg-black/80 dark:bg-white dark:text-black dark:hover:bg-white/80"
+            href="/auth/register"
+          >
+            Utwórz konto
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side `AppHeader` component with navigation links and auth actions
- integrate the new header into the root layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca658c61248322b0d978b395d7228f