### PR TITLE
Configure static export for Next.js

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js build for static export by enabling `output: "export"`
- disable Next.js image optimization to ensure compatibility with static hosting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca7865f5448322b2bdcfa906a20cfb