### PR TITLE
test: render verify page with client renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@testing-library/react": "^16.3.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -77,6 +78,43 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -2262,6 +2300,66 @@
         "tailwindcss": "4.1.13"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2272,6 +2370,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3058,6 +3164,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3813,6 +3930,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
@@ -3835,6 +3963,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6042,6 +6178,17 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -6610,6 +6757,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/auth/verify/page.test.tsx
+++ b/src/app/auth/verify/page.test.tsx
@@ -1,47 +1,93 @@
-import type { ReactElement, ReactNode } from "react";
-import { Children, isValidElement } from "react";
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { redirectMock, getSupabaseConfigMock, getUserMock, createSupabaseServerClientMock } = vi.hoisted(() => {
+type VerificationHandlerProps = {
+  code?: string | null;
+  tokenHash?: string | null;
+  type?: string | null;
+  redirectPath?: string;
+};
+
+const {
+  redirectMock,
+  replaceMock,
+  refreshMock,
+  isSupabaseConfiguredMock,
+  createSupabaseBrowserClientMock,
+  getUserMock,
+  verificationHandlerMock,
+} = vi.hoisted(() => {
+  const redirect = vi.fn();
+  const replace = vi.fn();
+  const refresh = vi.fn();
+  const isSupabaseConfigured = vi.fn();
   const getUser = vi.fn();
+  const supabaseClient = { auth: { getUser } };
+  const createSupabaseBrowserClient = vi.fn(() => supabaseClient);
+  const verificationHandler = vi.fn();
 
   return {
-    redirectMock: vi.fn(() => {
-      throw new Error("REDIRECT");
-    }),
-    getSupabaseConfigMock: vi.fn(),
+    redirectMock: redirect,
+    replaceMock: replace,
+    refreshMock: refresh,
+    isSupabaseConfiguredMock: isSupabaseConfigured,
+    createSupabaseBrowserClientMock: createSupabaseBrowserClient,
     getUserMock: getUser,
-    createSupabaseServerClientMock: vi.fn(() => ({
-      auth: {
-        getUser,
-      },
-    })),
+    verificationHandlerMock: verificationHandler,
   };
 });
 
 vi.mock("next/navigation", () => ({
   redirect: redirectMock,
-  useRouter: vi.fn(() => ({
-    replace: vi.fn(),
-    refresh: vi.fn(),
-  })),
+  useRouter: () => ({
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
 }));
 
-vi.mock("@/lib/env", () => ({
-  getSupabaseConfig: getSupabaseConfigMock,
+vi.mock("@/lib/envClient", () => ({
+  isSupabaseConfiguredOnClient: isSupabaseConfiguredMock,
 }));
 
-vi.mock("@/lib/supabaseServer", () => ({
-  createSupabaseServerClient: createSupabaseServerClientMock,
+vi.mock("@/lib/supabaseClient", () => ({
+  createSupabaseBrowserClient: createSupabaseBrowserClientMock,
 }));
 
-import { VerificationHandler } from "@/components/auth/VerificationHandler";
+vi.mock("@/components/auth/VerificationHandler", () => ({
+  VerificationHandler: (props: VerificationHandlerProps) => {
+    verificationHandlerMock(props);
+    return <div data-testid="verification-handler" />;
+  },
+}));
+
+vi.mock("@/components/auth/AuthForm", () => ({
+  AuthForm: () => <div data-testid="auth-form" />,
+}));
+
 import VerifyPage from "./page";
 
 describe("VerifyPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getSupabaseConfigMock.mockReturnValue({ url: "https://example.com" });
+    window.history.replaceState(null, "", "/");
+    isSupabaseConfiguredMock.mockReturnValue(true);
+    getUserMock.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("renders a Supabase configuration warning when env vars are missing", () => {
+    isSupabaseConfiguredMock.mockReturnValue(false);
+
+    render(<VerifyPage />);
+
+    expect(
+      screen.queryByText(
+        "Add your Supabase credentials to complete email verification flows.",
+      ),
+    ).not.toBeNull();
+    expect(createSupabaseBrowserClientMock).not.toHaveBeenCalled();
+    expect(verificationHandlerMock).not.toHaveBeenCalled();
   });
 
   it("redirects signed-in users when no verification payload is present", async () => {
@@ -49,84 +95,42 @@ describe("VerifyPage", () => {
       data: { user: { id: "user-123" } },
     });
 
-    await expect(VerifyPage({ searchParams: {} })).rejects.toThrowError("REDIRECT");
+    render(<VerifyPage />);
 
-    expect(redirectMock).toHaveBeenCalledWith("/dashboard");
+    await waitFor(() => {
+      expect(getUserMock).toHaveBeenCalledTimes(1);
+      expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    });
+
+    expect(verificationHandlerMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        code: null,
+        tokenHash: null,
+        type: null,
+      }),
+    );
   });
 
-  it("renders the verification handler for email change links when the user is already signed in", async () => {
-    getUserMock.mockResolvedValue({
-      data: { user: { id: "user-123" } },
+  it("renders the verification handler when the verification params are present", async () => {
+    window.history.pushState(
+      null,
+      "",
+      "/auth/verify?code=test-token&type=email_change",
+    );
+
+    render(<VerifyPage />);
+
+    await waitFor(() => {
+      expect(verificationHandlerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: "test-token",
+          tokenHash: null,
+          type: "email_change",
+        }),
+      );
     });
 
-    const element = await VerifyPage({
-      searchParams: {
-        code: "test-token",
-        type: "email_change",
-      },
-    });
-
-    expect(redirectMock).not.toHaveBeenCalled();
-
-    const verificationElement = findVerificationHandler(element);
-    expect(verificationElement).not.toBeNull();
-    expect(verificationElement?.props.code).toBe("test-token");
-    expect(verificationElement?.props.tokenHash).toBeNull();
-    expect(verificationElement?.props.type).toBe("email_change");
-  });
-
-  it("renders the verification handler when only a token hash is provided", async () => {
-    getUserMock.mockResolvedValue({
-      data: { user: { id: "user-123" } },
-    });
-
-    const element = await VerifyPage({
-      searchParams: {
-        token_hash: "test-token-hash",
-        type: "email_change",
-      },
-    });
-
-    expect(redirectMock).not.toHaveBeenCalled();
-
-    const verificationElement = findVerificationHandler(element);
-    expect(verificationElement).not.toBeNull();
-    expect(verificationElement?.props.code).toBeNull();
-    expect(verificationElement?.props.tokenHash).toBe("test-token-hash");
-    expect(verificationElement?.props.type).toBe("email_change");
+    expect(getUserMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 });
-
-function findVerificationHandler(node: ReactNode): ReactElement | null {
-  if (!node) {
-    return null;
-  }
-
-  if (Array.isArray(node)) {
-    for (const child of node) {
-      const match = findVerificationHandler(child);
-      if (match) {
-        return match;
-      }
-    }
-    return null;
-  }
-
-  if (!isValidElement(node)) {
-    return null;
-  }
-
-  if (node.type === VerificationHandler) {
-    return node;
-  }
-
-  const children = Children.toArray(node.props?.children ?? []);
-  for (const child of children) {
-    const match = findVerificationHandler(child);
-    if (match) {
-      return match;
-    }
-  }
-
-  return null;
-}


### PR DESCRIPTION
## Summary
- render the verify page in a jsdom environment to run client hooks during tests
- mock the client env helpers, Supabase browser client, and dependent components to validate warning and verification flows
- add @testing-library/react for client-side rendering utilities

## Testing
- npm run test -- run src/app/auth/verify/page.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca884a59588322935e7f7a7a9af667