### PR TITLE
Refactor footer year to client component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
+import AppFooter from "@/components/layout/AppFooter";
 import AppHeader from "@/components/layout/AppHeader";
-import Link from "next/link";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -13,22 +13,13 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const year = new Date().getFullYear();
-
   return (
     <html lang="en">
       <body className="font-sans bg-[var(--background)] text-[var(--foreground)] antialiased">
         <div className="flex min-h-screen flex-col">
           <AppHeader />
           <main className="flex flex-1 flex-col">{children}</main>
-          <footer className="border-t border-black/10 bg-white/80 px-4 py-6 text-sm text-black/60 dark:border-white/10 dark:bg-neutral-900/80 dark:text-white/60">
-            <div className="mx-auto flex w-full max-w-5xl items-center justify-between">
-              <span>&copy; {year} Meblomat. All rights reserved.</span>
-              <Link className="font-medium text-black transition hover:text-black/80 dark:text-white dark:hover:text-white/80" href="/auth/register">
-                Get started
-              </Link>
-            </div>
-          </footer>
+          <AppFooter />
         </div>
       </body>
     </html>

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const FALLBACK_YEAR = "";
+
+export default function AppFooter() {
+  const [year, setYear] = useState<string>(FALLBACK_YEAR);
+
+  useEffect(() => {
+    setYear(String(new Date().getFullYear()));
+  }, []);
+
+  return (
+    <footer className="border-t border-black/10 bg-white/80 px-4 py-6 text-sm text-black/60 dark:border-white/10 dark:bg-neutral-900/80 dark:text-white/60">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between">
+        <span>
+          &copy; {year ? `${year} ` : ""}Meblomat. All rights reserved.
+        </span>
+        <Link className="font-medium text-black transition hover:text-black/80 dark:text-white dark:hover:text-white/80" href="/auth/register">
+          Get started
+        </Link>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- move footer markup into a client component to compute the current year on the client
- keep the root layout static-friendly by consuming the new footer component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca918fb4bc83228dede4b769b7ee1f