### PR TITLE
Add browser Supabase config getter

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,4 @@
-export type SupabaseConfig = {
-  url: string;
-  anonKey: string;
-};
+import type { SupabaseConfig } from "./supabaseConfig";
 
 const SUPABASE_URL_ENV = "NEXT_PUBLIC_SUPABASE_URL";
 const SUPABASE_ANON_KEY_ENV = "NEXT_PUBLIC_SUPABASE_ANON_KEY";

--- a/src/lib/envClient.ts
+++ b/src/lib/envClient.ts
@@ -1,3 +1,8 @@
+import type { SupabaseConfig } from "./supabaseConfig";
+
+const SUPABASE_URL_ENV = "NEXT_PUBLIC_SUPABASE_URL";
+const SUPABASE_ANON_KEY_ENV = "NEXT_PUBLIC_SUPABASE_ANON_KEY";
+
 function isValidHttpUrl(value: string) {
   try {
     const parsed = new URL(value);
@@ -23,4 +28,40 @@ export function isSupabaseConfiguredOnClient() {
   }
 
   return isValidHttpUrl(trimmedUrl);
+}
+
+export function getSupabaseBrowserConfigOrThrow(): SupabaseConfig {
+  const rawUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (typeof rawUrl !== "string") {
+    throw new Error(
+      `${SUPABASE_URL_ENV} must be set to your Supabase project URL (e.g. https://your-project.supabase.co).`,
+    );
+  }
+
+  const url = rawUrl.trim();
+
+  if (!url) {
+    throw new Error(
+      `${SUPABASE_URL_ENV} must be set to your Supabase project URL (e.g. https://your-project.supabase.co).`,
+    );
+  }
+
+  if (!isValidHttpUrl(url)) {
+    throw new Error(`${SUPABASE_URL_ENV} must be a valid HTTP or HTTPS URL.`);
+  }
+
+  const rawAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (typeof rawAnonKey !== "string") {
+    throw new Error(`${SUPABASE_ANON_KEY_ENV} must be set to your Supabase anon public key.`);
+  }
+
+  const anonKey = rawAnonKey.trim();
+
+  if (!anonKey) {
+    throw new Error(`${SUPABASE_ANON_KEY_ENV} must be set to your Supabase anon public key.`);
+  }
+
+  return { url, anonKey };
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,12 +1,12 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-import { getSupabaseConfigOrThrow } from "./env";
+import { getSupabaseBrowserConfigOrThrow } from "./envClient";
 
 let client: SupabaseClient | undefined;
 
 export function createSupabaseBrowserClient() {
   if (!client) {
-    const { url, anonKey } = getSupabaseConfigOrThrow();
+    const { url, anonKey } = getSupabaseBrowserConfigOrThrow();
     client = createClient(url, anonKey, {
       auth: {
         persistSession: true,

--- a/src/lib/supabaseConfig.ts
+++ b/src/lib/supabaseConfig.ts
@@ -1,0 +1,4 @@
+export type SupabaseConfig = {
+  url: string;
+  anonKey: string;
+};


### PR DESCRIPTION
## Summary
- add a shared SupabaseConfig type definition for client and server utilities
- implement getSupabaseBrowserConfigOrThrow to read and validate public Supabase env vars on the client
- update the browser Supabase client factory to rely on the client env helper

## Testing
- NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run dev # verified /auth/login and /auth/register render without errors


------
https://chatgpt.com/codex/tasks/task_e_68caead1072c83229392ff1bf2e507d8