### PR TITLE
Add dashboard avatar management

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,15 +1,31 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { SupabaseEnvWarning } from "@/components/SupabaseEnvWarning";
+import { AvatarPicker } from "@/components/dashboard/AvatarPicker";
+import { UserAvatar } from "@/components/layout/UserAvatar";
+import {
+  DEFAULT_AVATAR_ID,
+  getAvatarPresetIcon,
+  type AvatarType,
+} from "@/lib/avatar";
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
 
 type ProfileRow = {
   subscription_expires_at: string | null;
+  avatar_type: AvatarType | null;
+  avatar_path: string | null;
+};
+
+type AvatarChangePayload = {
+  type: AvatarType;
+  path: string;
+  imageUrl: string | null;
+  error?: string | null;
 };
 
 const ONE_WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
@@ -48,8 +64,37 @@ export default function DashboardPage() {
   );
   const [isLoading, setIsLoading] = useState(true);
   const [userEmail, setUserEmail] = useState<string | null>(null);
-  const [subscriptionExpiresAt, setSubscriptionExpiresAt] = useState<string | null>(null);
+  const [subscriptionExpiresAt, setSubscriptionExpiresAt] =
+    useState<string | null>(null);
   const [profileError, setProfileError] = useState(false);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [avatarType, setAvatarType] = useState<AvatarType>("icon");
+  const [avatarPath, setAvatarPath] = useState<string>(DEFAULT_AVATAR_ID);
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [avatarLoadError, setAvatarLoadError] = useState<string | null>(null);
+
+  const handleAvatarChange = useCallback(
+    (change: AvatarChangePayload) => {
+      const normalizedPath = change.path || DEFAULT_AVATAR_ID;
+      const nextType: AvatarType = change.type === "upload" ? "upload" : "icon";
+
+      setAvatarType(nextType);
+      setAvatarPath(normalizedPath);
+
+      if (nextType === "upload") {
+        setAvatarUrl(change.imageUrl ?? null);
+        setAvatarLoadError(
+          change.error
+            ? "Nie udało się wczytać podglądu avatara. Spróbuj odświeżyć stronę lub wybrać plik ponownie."
+            : null,
+        );
+      } else {
+        setAvatarUrl(null);
+        setAvatarLoadError(null);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!supabase) {
@@ -76,15 +121,46 @@ export default function DashboardPage() {
       }
 
       setUserEmail(user.email ?? null);
+      setUserId(user.id);
 
-      const { data: profile, error: profileFetchError } = await supabase
+      const {
+        data: profile,
+        error: profileFetchError,
+      } = await supabase
         .from("profiles")
-        .select("subscription_expires_at")
+        .select("subscription_expires_at, avatar_type, avatar_path")
         .eq("id", user.id)
         .maybeSingle<ProfileRow>();
 
       if (!active) {
         return;
+      }
+
+      let nextAvatarType: AvatarType = "icon";
+      let nextAvatarPath = DEFAULT_AVATAR_ID;
+      let nextAvatarUrl: string | null = null;
+      let hasPreviewError = false;
+
+      if (!profileFetchError && profile) {
+        nextAvatarType = profile.avatar_type === "upload" ? "upload" : "icon";
+        nextAvatarPath = profile.avatar_path ?? DEFAULT_AVATAR_ID;
+
+        if (nextAvatarType === "upload" && profile.avatar_path) {
+          const { data: signedUrlData, error: signedUrlError } =
+            await supabase.storage
+              .from("avatars")
+              .createSignedUrl(profile.avatar_path, 60 * 60 * 24 * 7);
+
+          if (!active) {
+            return;
+          }
+
+          if (signedUrlError) {
+            hasPreviewError = true;
+          } else {
+            nextAvatarUrl = signedUrlData?.signedUrl ?? null;
+          }
+        }
       }
 
       if (profileFetchError) {
@@ -95,6 +171,13 @@ export default function DashboardPage() {
         setSubscriptionExpiresAt(profile?.subscription_expires_at ?? null);
       }
 
+      handleAvatarChange({
+        type: nextAvatarType,
+        path: nextAvatarPath,
+        imageUrl: nextAvatarUrl,
+        error: hasPreviewError ? "preview-error" : null,
+      });
+
       setIsLoading(false);
     };
 
@@ -103,13 +186,19 @@ export default function DashboardPage() {
         return;
       }
 
+      handleAvatarChange({
+        type: "icon",
+        path: DEFAULT_AVATAR_ID,
+        imageUrl: null,
+        error: null,
+      });
       router.replace("/auth/login");
     });
 
     return () => {
       active = false;
     };
-  }, [router, supabase]);
+  }, [handleAvatarChange, router, supabase]);
 
   if (!isSupabaseConfigured) {
     return (
@@ -165,6 +254,16 @@ export default function DashboardPage() {
     }
   }
 
+  const avatarPresetIcon = getAvatarPresetIcon(avatarPath);
+  const avatarInitials = userEmail?.[0]?.toUpperCase();
+  const showPreviewLoadingMessage =
+    avatarType === "upload" && !avatarUrl && !avatarLoadError;
+  const avatarFallbackIcon = (
+    <span aria-hidden="true" className="text-2xl">
+      {avatarPresetIcon}
+    </span>
+  );
+
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 px-4 py-16">
       <header className="space-y-2">
@@ -214,6 +313,45 @@ export default function DashboardPage() {
             >
               Contact support
             </a>
+          </div>
+        </article>
+
+        <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900 md:col-span-2">
+          <h2 className="text-lg font-semibold">Avatar</h2>
+          <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
+            Wybierz ikonę, która będzie widoczna w nagłówku i na dashboardzie.
+          </p>
+          <div className="mt-4 flex flex-col gap-4 md:flex-row md:items-center">
+            <UserAvatar
+              imageUrl={avatarType === "upload" ? avatarUrl : null}
+              fallbackIcon={avatarFallbackIcon}
+              initials={avatarInitials}
+              className="size-16 text-2xl"
+            />
+            <div className="text-sm/6 text-black/60 dark:text-white/60">
+              {avatarLoadError ? (
+                <p className="text-red-600 dark:text-red-400">{avatarLoadError}</p>
+              ) : showPreviewLoadingMessage ? (
+                <p>Trwa generowanie podglądu przesłanego obrazu…</p>
+              ) : (
+                <p>Tak będzie wyglądał Twój profil w aplikacji.</p>
+              )}
+            </div>
+          </div>
+          <div className="mt-6">
+            {supabase && userId ? (
+              <AvatarPicker
+                supabase={supabase}
+                userId={userId}
+                currentAvatarType={avatarType}
+                currentAvatarPath={avatarPath}
+                onAvatarChange={handleAvatarChange}
+              />
+            ) : (
+              <p className="text-sm/6 text-black/60 dark:text-white/60">
+                Zaloguj się, aby zmienić avatar.
+              </p>
+            )}
           </div>
         </article>
       </section>

--- a/src/components/dashboard/AvatarPicker.tsx
+++ b/src/components/dashboard/AvatarPicker.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useMemo, useState, type ChangeEvent } from "react";
+import clsx from "classnames";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  AVATAR_PRESETS,
+  DEFAULT_AVATAR_ID,
+  type AvatarType,
+} from "@/lib/avatar";
+
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB
+const SIGNED_URL_LIFETIME_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+type AvatarChange = {
+  type: AvatarType;
+  path: string;
+  imageUrl: string | null;
+  error?: string | null;
+};
+
+type Props = {
+  supabase: SupabaseClient;
+  userId: string;
+  currentAvatarType: AvatarType;
+  currentAvatarPath?: string | null;
+  onAvatarChange: (change: AvatarChange) => void;
+};
+
+type UploadProgressState = "idle" | "saving" | "uploading";
+
+type StatusMessage = {
+  tone: "neutral" | "error" | "success";
+  text: string;
+};
+
+function buildUniqueFilePath(userId: string, fileName: string) {
+  const cleanName = fileName
+    .toLowerCase()
+    .replace(/[^a-z0-9.\-_]+/gi, "_");
+  const uniqueId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  return `${userId}/${uniqueId}-${cleanName}`;
+}
+
+export function AvatarPicker({
+  supabase,
+  userId,
+  currentAvatarType,
+  currentAvatarPath,
+  onAvatarChange,
+}: Props) {
+  const [progress, setProgress] = useState<UploadProgressState>("idle");
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+
+  const normalizedPath = useMemo(
+    () => currentAvatarPath ?? DEFAULT_AVATAR_ID,
+    [currentAvatarPath],
+  );
+
+  const handlePresetSelection = async (presetId: string) => {
+    if (progress !== "idle") {
+      return;
+    }
+
+    if (currentAvatarType === "icon" && normalizedPath === presetId) {
+      setStatus({ tone: "success", text: "To już Twój aktualny avatar." });
+      return;
+    }
+
+    setProgress("saving");
+    setStatus({ tone: "neutral", text: "Zapisuję zmiany…" });
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({ avatar_type: "icon", avatar_path: presetId })
+      .eq("id", userId);
+
+    if (error) {
+      setStatus({
+        tone: "error",
+        text:
+          "Nie udało się zapisać ikonki. Spróbuj ponownie lub wybierz inną opcję.",
+      });
+      setProgress("idle");
+      return;
+    }
+
+    onAvatarChange({
+      type: "icon",
+      path: presetId,
+      imageUrl: null,
+      error: null,
+    });
+    setStatus({ tone: "success", text: "Zmieniono avatar." });
+    setProgress("idle");
+  };
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    // Allow re-selecting the same file later.
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    if (progress !== "idle") {
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setStatus({
+        tone: "error",
+        text: "Plik jest za duży. Maksymalny rozmiar to 2MB.",
+      });
+      return;
+    }
+
+    setProgress("uploading");
+    setStatus({ tone: "neutral", text: "Wysyłam plik…" });
+
+    const storagePath = buildUniqueFilePath(userId, file.name);
+    const { error: uploadError } = await supabase.storage
+      .from("avatars")
+      .upload(storagePath, file, {
+        cacheControl: "3600",
+        upsert: true,
+        contentType: file.type,
+      });
+
+    if (uploadError) {
+      setStatus({
+        tone: "error",
+        text:
+          "Nie udało się wgrać pliku. Upewnij się, że masz dostęp do internetu i spróbuj ponownie.",
+      });
+      setProgress("idle");
+      return;
+    }
+
+    const { error: updateError } = await supabase
+      .from("profiles")
+      .update({ avatar_type: "upload", avatar_path: storagePath })
+      .eq("id", userId);
+
+    if (updateError) {
+      setStatus({
+        tone: "error",
+        text: "Nie udało się zapisać avatara. Spróbuj ponownie później.",
+      });
+      setProgress("idle");
+      return;
+    }
+
+    const { data: signedUrlData, error: signedUrlError } = await supabase.storage
+      .from("avatars")
+      .createSignedUrl(storagePath, SIGNED_URL_LIFETIME_SECONDS);
+
+    const signedUrl = signedUrlData?.signedUrl ?? null;
+
+    onAvatarChange({
+      type: "upload",
+      path: storagePath,
+      imageUrl: signedUrl,
+      error: signedUrlError ? signedUrlError.message : null,
+    });
+
+    if (signedUrlError) {
+      setStatus({
+        tone: "error",
+        text: "Avatar został zapisany, ale nie udało się wygenerować podglądu.",
+      });
+      setProgress("idle");
+      return;
+    }
+
+    setStatus({ tone: "success", text: "Nowy avatar jest gotowy!" });
+    setProgress("idle");
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-3">
+        {AVATAR_PRESETS.map((preset) => {
+          const isActive =
+            currentAvatarType === "icon" && normalizedPath === preset.id;
+
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              disabled={progress !== "idle"}
+              className={clsx(
+                "inline-flex size-12 items-center justify-center rounded-full border px-0 text-xl transition",
+                "border-black/10 text-black hover:border-black/30 hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:border-white/40 dark:hover:bg-white/10",
+                isActive &&
+                  "border-black/50 bg-black/5 dark:border-white/50 dark:bg-white/10",
+                progress !== "idle" && "opacity-60",
+              )}
+              onClick={() => handlePresetSelection(preset.id)}
+            >
+              <span aria-hidden="true">{preset.icon}</span>
+              <span className="sr-only">Wybierz ikonę {preset.label}</span>
+            </button>
+          );
+        })}
+
+        <label
+          className={clsx(
+            "inline-flex cursor-pointer items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition",
+            "border-black/10 text-black hover:border-black/30 hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:border-white/40 dark:hover:bg-white/10",
+            progress !== "idle" && "opacity-60",
+          )}
+        >
+          <input
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            className="sr-only"
+            onChange={handleFileChange}
+            disabled={progress !== "idle"}
+          />
+          <span>Wgraj własne logo</span>
+        </label>
+      </div>
+
+      <p className="text-xs text-black/50 dark:text-white/50">
+        Obsługiwane formaty: PNG, JPG, GIF i WebP. Maksymalnie 2MB.
+      </p>
+
+      {status ? (
+        <p
+          className={clsx("text-sm", {
+            "text-emerald-600 dark:text-emerald-400": status.tone === "success",
+            "text-red-600 dark:text-red-400": status.tone === "error",
+            "text-black/60 dark:text-white/60": status.tone === "neutral",
+          })}
+        >
+          {status.text}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -6,6 +6,11 @@ import type { User } from "@supabase/supabase-js";
 
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
+import {
+  DEFAULT_AVATAR_ID,
+  getAvatarPresetIcon,
+  type AvatarType,
+} from "@/lib/avatar";
 
 import { UserAvatar } from "./UserAvatar";
 
@@ -24,7 +29,8 @@ const navigationLinks: NavigationLink[] = [
 ];
 
 type ProfileRow = {
-  avatar_url?: string | null;
+  avatar_type: AvatarType | null;
+  avatar_path: string | null;
 };
 
 export default function AppHeader() {
@@ -35,11 +41,13 @@ export default function AppHeader() {
   );
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<ProfileRow | null>(null);
+  const [avatarImageUrl, setAvatarImageUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (!supabase) {
       setUser(null);
       setProfile(null);
+      setAvatarImageUrl(null);
       return;
     }
 
@@ -48,7 +56,7 @@ export default function AppHeader() {
     const loadProfile = async (userId: string) => {
       const { data, error } = await supabase
         .from("profiles")
-        .select("*")
+        .select("avatar_type, avatar_path")
         .eq("id", userId)
         .maybeSingle<ProfileRow>();
 
@@ -58,10 +66,14 @@ export default function AppHeader() {
 
       if (error) {
         setProfile(null);
+        setAvatarImageUrl(null);
         return;
       }
 
       setProfile(data ?? null);
+      if (!data) {
+        setAvatarImageUrl(null);
+      }
     };
 
     const syncUser = async () => {
@@ -77,6 +89,7 @@ export default function AppHeader() {
       if (error || !currentUser) {
         setUser(null);
         setProfile(null);
+        setAvatarImageUrl(null);
         return;
       }
 
@@ -91,6 +104,7 @@ export default function AppHeader() {
 
       setUser(null);
       setProfile(null);
+      setAvatarImageUrl(null);
     });
 
     const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
@@ -108,9 +122,11 @@ export default function AppHeader() {
           }
 
           setProfile(null);
+          setAvatarImageUrl(null);
         });
       } else {
         setProfile(null);
+        setAvatarImageUrl(null);
       }
     });
 
@@ -120,13 +136,84 @@ export default function AppHeader() {
     };
   }, [supabase]);
 
+  const avatarPath = profile?.avatar_path ?? null;
+  const avatarType = profile?.avatar_type ?? null;
+
+  useEffect(() => {
+    if (!supabase) {
+      setAvatarImageUrl(null);
+      return;
+    }
+
+    if (avatarType !== "upload" || !avatarPath) {
+      setAvatarImageUrl(null);
+      return;
+    }
+
+    let active = true;
+
+    supabase.storage
+      .from("avatars")
+      .createSignedUrl(avatarPath, 60 * 60 * 24 * 7)
+      .then(({ data, error }) => {
+        if (!active) {
+          return;
+        }
+
+        if (error) {
+          setAvatarImageUrl(null);
+        } else {
+          setAvatarImageUrl(data?.signedUrl ?? null);
+        }
+      })
+      .catch(() => {
+        if (!active) {
+          return;
+        }
+
+        setAvatarImageUrl(null);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [avatarPath, avatarType, supabase]);
+
+  useEffect(() => {
+    if (!supabase || !user?.id) {
+      return;
+    }
+
+    const channel = supabase
+      .channel(`profile-avatar-${user.id}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "profiles",
+          filter: `id=eq.${user.id}`,
+        },
+        (payload) => {
+          setProfile((payload.new as ProfileRow) ?? null);
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [supabase, user?.id]);
+
   const isAuthenticated = Boolean(user);
-  const avatarUrl =
-    profile?.avatar_url ??
-    (typeof user?.user_metadata?.avatar_url === "string"
-      ? (user.user_metadata.avatar_url as string)
-      : null);
-  const avatarFallback = user?.email?.[0]?.toUpperCase() ?? undefined;
+  const presetIcon = getAvatarPresetIcon(avatarPath ?? DEFAULT_AVATAR_ID);
+  const avatarFallbackIcon = (
+    <span aria-hidden="true" className="text-base">
+      {presetIcon}
+    </span>
+  );
+  const resolvedAvatarUrl = avatarType === "upload" ? avatarImageUrl : null;
+  const avatarInitial = user?.email?.[0]?.toUpperCase() ?? undefined;
 
   return (
     <header className="border-b border-black/10 bg-white/80 px-4 py-4 backdrop-blur-sm dark:border-white/10 dark:bg-neutral-900/80">
@@ -160,7 +247,11 @@ export default function AppHeader() {
         <div className="flex flex-col items-end gap-3 text-sm font-medium">
           {isAuthenticated ? (
             <Link href="/dashboard" className="rounded-full">
-              <UserAvatar imageUrl={avatarUrl} initials={avatarFallback} />
+              <UserAvatar
+                imageUrl={resolvedAvatarUrl}
+                fallbackIcon={avatarFallbackIcon}
+                initials={avatarInitial}
+              />
             </Link>
           ) : (
             <div className="flex items-center gap-3">

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,28 @@
+export type AvatarType = "icon" | "upload";
+
+export type AvatarPreset = {
+  id: string;
+  label: string;
+  icon: string;
+};
+
+export const DEFAULT_AVATAR_ID = "user";
+
+export const AVATAR_PRESETS: AvatarPreset[] = [
+  { id: "user", label: "Classic", icon: "👤" },
+  { id: "hammer", label: "Workshop", icon: "🔨" },
+  { id: "sparkles", label: "Spark", icon: "✨" },
+  { id: "leaf", label: "Nature", icon: "🍃" },
+  { id: "compass", label: "Navigator", icon: "🧭" },
+  { id: "lightbulb", label: "Idea", icon: "💡" },
+];
+
+export function getAvatarPresetIcon(id: string | null | undefined) {
+  const preset = AVATAR_PRESETS.find((item) => item.id === id);
+
+  if (preset) {
+    return preset.icon;
+  }
+
+  return AVATAR_PRESETS[0]?.icon ?? "👤";
+}


### PR DESCRIPTION
## Summary
- load avatar metadata in the dashboard, render a dedicated preview section, and reuse the shared UserAvatar component
- implement an AvatarPicker with preset icons, file uploads via Supabase Storage, and success/error feedback when saving choices
- update the application header to consume the new avatar data and refresh when the profile changes

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb0284751083228609c2cf610092eb