### PR TITLE
Add carpenter-client collaboration flows

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -22,7 +22,18 @@ function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpFormProps) 
   const router = useRouter();
   const searchParams = useSearchParams();
   const invitationToken = searchParams?.get("invitation") ?? undefined;
-  const forcedAccountType: AccountType | undefined = invitationToken ? "carpenter" : undefined;
+  const accountParam = searchParams?.get("account");
+  const forcedAccountType: AccountType | undefined = (() => {
+    if (accountParam === "carpenter" || accountParam === "client") {
+      return accountParam;
+    }
+
+    if (invitationToken) {
+      return "client";
+    }
+
+    return undefined;
+  })();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [accountType, setAccountType] = useState<AccountType>(forcedAccountType ?? "client");

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -12,13 +12,31 @@ import {
   getAvatarPresetIcon,
   type AvatarType,
 } from "@/lib/avatar";
+import {
+  listActiveCarpenters,
+  listCarpenterClients,
+  type ActiveCarpenter,
+  type AssignedCarpenter,
+  type CarpenterClient,
+  getAssignedCarpenter,
+} from "@/lib/carpenters";
+import { generateInvitation } from "@/lib/invitations";
+import {
+  fetchProjectsForCarpenter,
+  fetchProjectsForClient,
+  submitProjectBrief,
+  type ProjectRecord,
+} from "@/lib/projects";
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
+
+type AccountType = "carpenter" | "client" | "admin";
 
 type ProfileRow = {
   subscription_expires_at: string | null;
   avatar_type: AvatarType | null;
   avatar_path: string | null;
+  account_type: AccountType | null;
 };
 
 type AvatarChangePayload = {
@@ -28,9 +46,16 @@ type AvatarChangePayload = {
   error?: string | null;
 };
 
+type InvitationRow = {
+  token: string;
+  invitedEmail: string;
+  expiresAt: string;
+  acceptedAt: string | null;
+};
+
 const ONE_WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 
-function parseExpiration(value: string | null | undefined) {
+function parseDate(value: string | null | undefined) {
   if (!value) {
     return null;
   }
@@ -68,10 +93,48 @@ export default function DashboardPage() {
     useState<string | null>(null);
   const [profileError, setProfileError] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
+  const [accountType, setAccountType] = useState<AccountType | null>(null);
   const [avatarType, setAvatarType] = useState<AvatarType>("icon");
   const [avatarPath, setAvatarPath] = useState<string>(DEFAULT_AVATAR_ID);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [avatarLoadError, setAvatarLoadError] = useState<string | null>(null);
+  const [dashboardError, setDashboardError] = useState<string | null>(null);
+  const [invitations, setInvitations] = useState<InvitationRow[]>([]);
+  const [carpenterClients, setCarpenterClients] = useState<CarpenterClient[]>([]);
+  const [projects, setProjects] = useState<ProjectRecord[]>([]);
+  const [assignedCarpenter, setAssignedCarpenter] =
+    useState<AssignedCarpenter | null>(null);
+  const [availableCarpenters, setAvailableCarpenters] = useState<
+    ActiveCarpenter[]
+  >([]);
+  const [invitationEmail, setInvitationEmail] = useState("");
+  const [invitationLink, setInvitationLink] = useState<string | null>(null);
+  const [invitationError, setInvitationError] = useState<string | null>(null);
+  const [isInvitationSubmitting, setIsInvitationSubmitting] = useState(false);
+  const [inviteBaseUrl, setInviteBaseUrl] = useState<string | null>(null);
+  const [projectCarpenterId, setProjectCarpenterId] = useState<string | null>(
+    null,
+  );
+  const [projectTitle, setProjectTitle] = useState("");
+  const [projectDetails, setProjectDetails] = useState("");
+  const [projectSubmitError, setProjectSubmitError] = useState<string | null>(
+    null,
+  );
+  const [projectSubmitSuccess, setProjectSubmitSuccess] =
+    useState<string | null>(null);
+  const [isProjectSubmitting, setIsProjectSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      setInviteBaseUrl(window.location.origin);
+    } catch {
+      setInviteBaseUrl(null);
+    }
+  }, []);
 
   const handleAvatarChange = useCallback(
     (change: AvatarChangePayload) => {
@@ -128,7 +191,9 @@ export default function DashboardPage() {
         error: profileFetchError,
       } = await supabase
         .from("profiles")
-        .select("subscription_expires_at, avatar_type, avatar_path")
+        .select(
+          "subscription_expires_at, avatar_type, avatar_path, account_type",
+        )
         .eq("id", user.id)
         .maybeSingle<ProfileRow>();
 
@@ -171,6 +236,8 @@ export default function DashboardPage() {
         setSubscriptionExpiresAt(profile?.subscription_expires_at ?? null);
       }
 
+      setAccountType(profile?.account_type ?? null);
+
       handleAvatarChange({
         type: nextAvatarType,
         path: nextAvatarPath,
@@ -200,6 +267,307 @@ export default function DashboardPage() {
     };
   }, [handleAvatarChange, router, supabase]);
 
+  const refreshCarpenterData = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!supabase || !userId) {
+        return;
+      }
+
+      setDashboardError(null);
+
+      try {
+        const [invitationResponse, clientsList, projectList] = await Promise.all([
+          supabase
+            .from("carpenter_invitations")
+            .select("token, invited_email, expires_at, accepted_at")
+            .eq("carpenter_id", userId)
+            .order("created_at", { ascending: false }),
+          listCarpenterClients(supabase),
+          fetchProjectsForCarpenter(supabase, userId),
+        ]);
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        if (invitationResponse.error) {
+          throw invitationResponse.error;
+        }
+
+        const normalizedInvitations: InvitationRow[] =
+          (invitationResponse.data ?? []).map((entry) => ({
+            token: entry.token as string,
+            invitedEmail: entry.invited_email as string,
+            expiresAt: entry.expires_at as string,
+            acceptedAt: (entry.accepted_at as string | null) ?? null,
+          }));
+
+        setInvitations(normalizedInvitations);
+        setCarpenterClients(clientsList);
+        setProjects(projectList);
+        setAssignedCarpenter(null);
+        setAvailableCarpenters([]);
+        setProjectCarpenterId(null);
+      } catch (error) {
+        if (signal?.aborted) {
+          return;
+        }
+
+        setDashboardError(
+          error instanceof Error
+            ? error.message
+            : "We couldn't load your collaboration data.",
+        );
+      }
+    },
+    [supabase, userId],
+  );
+
+  const refreshClientData = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!supabase || !userId) {
+        return;
+      }
+
+      setDashboardError(null);
+
+      try {
+        const [assignment, projectList] = await Promise.all([
+          getAssignedCarpenter(supabase),
+          fetchProjectsForClient(supabase, userId),
+        ]);
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        setAssignedCarpenter(assignment);
+        setProjects(projectList);
+        setInvitations([]);
+        setCarpenterClients([]);
+
+        if (assignment) {
+          setAvailableCarpenters([]);
+          setProjectCarpenterId(assignment.carpenterId);
+        } else {
+          const activeCarpentersList = await listActiveCarpenters(supabase);
+
+          if (signal?.aborted) {
+            return;
+          }
+
+          setAvailableCarpenters(activeCarpentersList);
+          setProjectCarpenterId((current) => {
+            if (
+              current &&
+              activeCarpentersList.some(
+                (carpenter) => carpenter.carpenterId === current,
+              )
+            ) {
+              return current;
+            }
+
+            return null;
+          });
+        }
+      } catch (error) {
+        if (signal?.aborted) {
+          return;
+        }
+
+        setDashboardError(
+          error instanceof Error
+            ? error.message
+            : "We couldn't load your collaboration data.",
+        );
+      }
+    },
+    [supabase, userId],
+  );
+
+  useEffect(() => {
+    if (!supabase || !userId || !accountType) {
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    if (accountType === "carpenter" || accountType === "admin") {
+      refreshCarpenterData(abortController.signal);
+    } else if (accountType === "client") {
+      refreshClientData(abortController.signal);
+    }
+
+    return () => {
+      abortController.abort();
+    };
+  }, [accountType, refreshCarpenterData, refreshClientData, supabase, userId]);
+
+  const handleInvitationSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      if (!supabase || !userId) {
+        return;
+      }
+
+      const normalizedEmail = invitationEmail.trim();
+
+      if (!normalizedEmail) {
+        setInvitationError("Enter an email address to invite a client.");
+        return;
+      }
+
+      setInvitationError(null);
+      setDashboardError(null);
+      setInvitationLink(null);
+      setIsInvitationSubmitting(true);
+
+      try {
+        const expiresAt = new Date(Date.now() + ONE_WEEK_IN_MS);
+        const invitation = await generateInvitation(
+          supabase,
+          userId,
+          normalizedEmail,
+          expiresAt,
+        );
+
+        const baseUrl = inviteBaseUrl ??
+          (typeof window !== "undefined" ? window.location.origin : "");
+        const shareUrl = baseUrl
+          ? `${baseUrl}/invite/${invitation.token}`
+          : `/invite/${invitation.token}`;
+
+        setInvitationLink(shareUrl);
+        setInvitationEmail("");
+        await refreshCarpenterData();
+      } catch (error) {
+        setDashboardError(
+          error instanceof Error
+            ? error.message
+            : "We couldn't create a new invitation.",
+        );
+      } finally {
+        setIsInvitationSubmitting(false);
+      }
+    },
+    [
+      supabase,
+      userId,
+      invitationEmail,
+      inviteBaseUrl,
+      refreshCarpenterData,
+    ],
+  );
+
+  const handleProjectSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      if (!supabase) {
+        return;
+      }
+
+      if (!projectCarpenterId) {
+        setProjectSubmitError("Choose a carpenter before submitting your project.");
+        return;
+      }
+
+      const normalizedTitle = projectTitle.trim();
+      const normalizedDetails = projectDetails.trim();
+
+      if (!normalizedTitle) {
+        setProjectSubmitError("Provide a short project title.");
+        return;
+      }
+
+      if (!normalizedDetails) {
+        setProjectSubmitError("Describe your project so the carpenter can respond.");
+        return;
+      }
+
+      setProjectSubmitError(null);
+      setProjectSubmitSuccess(null);
+      setIsProjectSubmitting(true);
+
+      try {
+        await submitProjectBrief(
+          supabase,
+          projectCarpenterId,
+          normalizedTitle,
+          normalizedDetails,
+        );
+
+        setProjectTitle("");
+        setProjectDetails("");
+        setProjectSubmitSuccess("Your project brief has been shared with the carpenter.");
+        await refreshClientData();
+      } catch (error) {
+        setProjectSubmitError(
+          error instanceof Error
+            ? error.message
+            : "We couldn't submit your project. Please try again.",
+        );
+      } finally {
+        setIsProjectSubmitting(false);
+      }
+    },
+    [
+      supabase,
+      projectCarpenterId,
+      projectTitle,
+      projectDetails,
+      refreshClientData,
+    ],
+  );
+
+  const expirationDate = parseDate(subscriptionExpiresAt);
+  const now = new Date();
+  const isCarpenterView = accountType === "carpenter" || accountType === "admin";
+  const isClientView = accountType === "client";
+  const pendingInvitations = useMemo(() => {
+    return invitations.filter((invitation) => {
+      if (invitation.acceptedAt) {
+        return false;
+      }
+
+      const expires = parseDate(invitation.expiresAt);
+      return !expires || expires.getTime() > Date.now();
+    });
+  }, [invitations]);
+  const projectsByClient = useMemo(() => {
+    const grouped = new Map<string, ProjectRecord[]>();
+
+    for (const project of projects) {
+      const entries = grouped.get(project.clientId);
+
+      if (entries) {
+        entries.push(project);
+      } else {
+        grouped.set(project.clientId, [project]);
+      }
+    }
+
+    return grouped;
+  }, [projects]);
+  const knownCarpenters = useMemo(() => {
+    const map = new Map<string, string | null>();
+
+    if (assignedCarpenter) {
+      map.set(
+        assignedCarpenter.carpenterId,
+        assignedCarpenter.carpenterEmail ?? null,
+      );
+    }
+
+    for (const carpenter of availableCarpenters) {
+      map.set(carpenter.carpenterId, carpenter.carpenterEmail ?? null);
+    }
+
+    return map;
+  }, [assignedCarpenter, availableCarpenters]);
+  const canSubmitProject = Boolean(projectCarpenterId);
+
   if (!isSupabaseConfigured) {
     return (
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-16">
@@ -220,9 +588,6 @@ export default function DashboardPage() {
       </div>
     );
   }
-
-  const expirationDate = parseExpiration(subscriptionExpiresAt);
-  const now = new Date();
 
   let warning: { title: string; description: string } | null = null;
 
@@ -355,6 +720,375 @@ export default function DashboardPage() {
           </div>
         </article>
       </section>
+
+      {dashboardError ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 px-6 py-5 text-red-800 dark:border-red-400/60 dark:bg-red-400/10 dark:text-red-100">
+          <h2 className="text-lg font-semibold">Collaboration data unavailable</h2>
+          <p className="mt-2 text-sm/6">{dashboardError}</p>
+        </div>
+      ) : null}
+
+      {isCarpenterView ? (
+        <section className="space-y-6">
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Invite a client</h2>
+            <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
+              Generate a secure link that connects new clients to your workspace.
+            </p>
+            <form className="mt-4 space-y-4" onSubmit={handleInvitationSubmit} noValidate>
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium text-black dark:text-white"
+                  htmlFor="invitation-email"
+                >
+                  Client email
+                </label>
+                <input
+                  id="invitation-email"
+                  type="email"
+                  autoComplete="email"
+                  className="w-full rounded-md border border-black/10 bg-white px-3 py-2 text-base text-black outline-none transition focus:border-black/40 focus:ring-2 focus:ring-black/20 dark:border-white/20 dark:bg-black dark:text-white dark:focus:border-white/40 dark:focus:ring-white/20"
+                  value={invitationEmail}
+                  onChange={(event) => setInvitationEmail(event.target.value)}
+                  required
+                />
+              </div>
+
+              {invitationError ? (
+                <p className="text-sm text-red-600 dark:text-red-400">{invitationError}</p>
+              ) : null}
+
+              {invitationLink ? (
+                <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-emerald-900 dark:border-emerald-400/60 dark:bg-emerald-400/10 dark:text-emerald-100">
+                  <p className="text-sm font-medium">Share this link with your client:</p>
+                  <p className="mt-1 break-all font-mono text-sm">{invitationLink}</p>
+                </div>
+              ) : null}
+
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-md bg-black px-4 py-2 text-sm font-semibold text-white transition hover:bg-black/90 focus:outline-none focus:ring-2 focus:ring-black/20 disabled:cursor-not-allowed disabled:bg-black/40 dark:bg-white dark:text-black dark:hover:bg-white/90 dark:focus:ring-white/30 dark:disabled:bg-white/40"
+                disabled={isInvitationSubmitting}
+              >
+                {isInvitationSubmitting ? "Generating link…" : "Generate invitation"}
+              </button>
+            </form>
+          </article>
+
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Pending invitations</h2>
+            <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
+              Track outstanding invitations that are waiting to be accepted.
+            </p>
+            {pendingInvitations.length > 0 ? (
+              <ul className="mt-4 space-y-4">
+                {pendingInvitations.map((invitation) => {
+                  const expires = parseDate(invitation.expiresAt);
+                  const shareUrl = inviteBaseUrl
+                    ? `${inviteBaseUrl}/invite/${invitation.token}`
+                    : `/invite/${invitation.token}`;
+
+                  return (
+                    <li
+                      key={invitation.token}
+                      className="rounded-2xl border border-black/10 bg-black/5 px-4 py-3 dark:border-white/10 dark:bg-white/5"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-black dark:text-white">
+                            {invitation.invitedEmail}
+                          </p>
+                          <p className="text-xs uppercase tracking-wide text-black/60 dark:text-white/60">
+                            Expires {formatDateTime(expires)}
+                          </p>
+                        </div>
+                        <Link
+                          className="text-sm font-medium text-black underline-offset-4 hover:underline dark:text-white"
+                          href={`/invite/${invitation.token}`}
+                        >
+                          Open invite
+                        </Link>
+                      </div>
+                      <p className="mt-2 break-all text-xs font-mono text-black/60 dark:text-white/60">
+                        {shareUrl}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="mt-4 text-sm/6 text-black/60 dark:text-white/60">
+                You don&apos;t have any pending invitations. Generate a new link to start collaborating with a client.
+              </p>
+            )}
+          </article>
+
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Assigned clients</h2>
+            <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
+              Review the clients connected to your workspace and see the latest briefs they have submitted.
+            </p>
+            {carpenterClients.length > 0 ? (
+              <ul className="mt-4 space-y-5">
+                {carpenterClients.map((client) => {
+                  const clientProjects = projectsByClient.get(client.clientId) ?? [];
+
+                  return (
+                    <li
+                      key={client.clientId}
+                      className="rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/10 dark:bg-white/5"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-black dark:text-white">
+                            {client.clientEmail ?? "Client"}
+                          </p>
+                          <p className="text-xs uppercase tracking-wide text-black/60 dark:text-white/60">
+                            ID: {client.clientId}
+                          </p>
+                        </div>
+                        <span className="inline-flex items-center rounded-full bg-black/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-black/80 dark:bg-white/10 dark:text-white/80">
+                          {clientProjects.length} {clientProjects.length === 1 ? "project" : "projects"}
+                        </span>
+                      </div>
+
+                      {clientProjects.length > 0 ? (
+                        <ul className="mt-3 space-y-3">
+                          {clientProjects.map((project) => {
+                            const submitted = parseDate(project.submittedAt);
+
+                            return (
+                              <li
+                                key={project.id}
+                                className="rounded-xl border border-black/10 bg-white/60 p-4 dark:border-white/10 dark:bg-neutral-900/60"
+                              >
+                                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                  <div>
+                                    <p className="text-sm font-semibold text-black dark:text-white">
+                                      {project.title}
+                                    </p>
+                                    {project.details ? (
+                                      <p className="mt-1 text-sm/6 text-black/70 dark:text-white/70">
+                                        {project.details}
+                                      </p>
+                                    ) : null}
+                                  </div>
+                                  <span className="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-800 dark:bg-emerald-400/10 dark:text-emerald-200">
+                                    {project.status.replace(/_/g, " ")}
+                                  </span>
+                                </div>
+                                <p className="mt-2 text-xs uppercase tracking-wide text-black/50 dark:text-white/50">
+                                  Submitted {formatDateTime(submitted)}
+                                </p>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : (
+                        <p className="mt-3 text-sm/6 text-black/60 dark:text-white/60">
+                          This client hasn&apos;t submitted any project briefs yet.
+                        </p>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="mt-4 text-sm/6 text-black/60 dark:text-white/60">
+                When clients accept your invitations they will appear here.
+              </p>
+            )}
+          </article>
+        </section>
+      ) : null}
+
+      {isClientView ? (
+        <section className="space-y-6">
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Your carpenter</h2>
+            {assignedCarpenter ? (
+              <div className="mt-3 space-y-2 text-sm/6 text-black/70 dark:text-white/70">
+                <p className="text-base font-semibold text-black dark:text-white">
+                  {assignedCarpenter.carpenterEmail ?? "Assigned carpenter"}
+                </p>
+                <p>
+                  You&apos;re connected to this carpenter for all future project briefs.
+                </p>
+              </div>
+            ) : (
+              <p className="mt-3 text-sm/6 text-black/60 dark:text-white/60">
+                You&apos;re not linked to a carpenter yet. Choose one below when you submit your first project brief.
+              </p>
+            )}
+          </article>
+
+          {!assignedCarpenter ? (
+            <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+              <h2 className="text-lg font-semibold">Available carpenters</h2>
+              <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
+                Only carpenters with an active subscription appear in this list.
+              </p>
+              {availableCarpenters.length > 0 ? (
+                <ul className="mt-4 space-y-3">
+                  {availableCarpenters.map((carpenter) => (
+                    <li
+                      key={carpenter.carpenterId}
+                      className="rounded-xl border border-black/10 bg-black/5 px-4 py-3 dark:border-white/10 dark:bg-white/5"
+                    >
+                      <p className="text-sm font-semibold text-black dark:text-white">
+                        {carpenter.carpenterEmail ?? "Carpenter"}
+                      </p>
+                      <p className="text-xs uppercase tracking-wide text-black/60 dark:text-white/60">
+                        Subscription valid until {formatDateTime(parseDate(carpenter.subscriptionExpiresAt))}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-4 text-sm/6 text-black/60 dark:text-white/60">
+                  No carpenters are accepting new collaborations right now. Check back later or contact support if you need urgent assistance.
+                </p>
+              )}
+            </article>
+          ) : null}
+
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Submit a project brief</h2>
+            <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
+              Share the details of your project and we&apos;ll notify the assigned carpenter instantly.
+            </p>
+            <form className="mt-4 space-y-4" onSubmit={handleProjectSubmit} noValidate>
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium text-black dark:text-white"
+                  htmlFor="project-carpenter"
+                >
+                  Carpenter
+                </label>
+                <select
+                  id="project-carpenter"
+                  className="w-full rounded-md border border-black/10 bg-white px-3 py-2 text-base text-black outline-none transition focus:border-black/40 focus:ring-2 focus:ring-black/20 dark:border-white/20 dark:bg-black dark:text-white dark:focus:border-white/40 dark:focus:ring-white/20"
+                  value={projectCarpenterId ?? ""}
+                  onChange={(event) => setProjectCarpenterId(event.target.value || null)}
+                  disabled={Boolean(assignedCarpenter)}
+                >
+                  {assignedCarpenter ? (
+                    <option value={assignedCarpenter.carpenterId}>
+                      {assignedCarpenter.carpenterEmail ?? "Assigned carpenter"}
+                    </option>
+                  ) : (
+                    <>
+                      <option value="">
+                        Select a carpenter
+                      </option>
+                      {availableCarpenters.map((carpenter) => (
+                        <option key={carpenter.carpenterId} value={carpenter.carpenterId}>
+                          {carpenter.carpenterEmail ?? carpenter.carpenterId}
+                        </option>
+                      ))}
+                    </>
+                  )}
+                </select>
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium text-black dark:text-white"
+                  htmlFor="project-title"
+                >
+                  Project title
+                </label>
+                <input
+                  id="project-title"
+                  type="text"
+                  className="w-full rounded-md border border-black/10 bg-white px-3 py-2 text-base text-black outline-none transition focus:border-black/40 focus:ring-2 focus:ring-black/20 dark:border-white/20 dark:bg-black dark:text-white dark:focus:border-white/40 dark:focus:ring-white/20"
+                  value={projectTitle}
+                  onChange={(event) => setProjectTitle(event.target.value)}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label
+                  className="text-sm font-medium text-black dark:text-white"
+                  htmlFor="project-details"
+                >
+                  Project details
+                </label>
+                <textarea
+                  id="project-details"
+                  className="w-full rounded-md border border-black/10 bg-white px-3 py-2 text-base text-black outline-none transition focus:border-black/40 focus:ring-2 focus:ring-black/20 dark:border-white/20 dark:bg-black dark:text-white dark:focus:border-white/40 dark:focus:ring-white/20"
+                  rows={5}
+                  value={projectDetails}
+                  onChange={(event) => setProjectDetails(event.target.value)}
+                  required
+                />
+              </div>
+
+              {projectSubmitError ? (
+                <p className="text-sm text-red-600 dark:text-red-400">{projectSubmitError}</p>
+              ) : null}
+
+              {projectSubmitSuccess ? (
+                <p className="text-sm text-emerald-600 dark:text-emerald-300">{projectSubmitSuccess}</p>
+              ) : null}
+
+              <button
+                type="submit"
+                className="inline-flex items-center justify-center rounded-md bg-black px-4 py-2 text-sm font-semibold text-white transition hover:bg-black/90 focus:outline-none focus:ring-2 focus:ring-black/20 disabled:cursor-not-allowed disabled:bg-black/40 dark:bg-white dark:text-black dark:hover:bg-white/90 dark:focus:ring-white/30 dark:disabled:bg-white/40"
+                disabled={isProjectSubmitting || !canSubmitProject}
+              >
+                {isProjectSubmitting ? "Sending brief…" : "Send project brief"}
+              </button>
+            </form>
+          </article>
+
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Your projects</h2>
+            {projects.length > 0 ? (
+              <ul className="mt-4 space-y-4">
+                {projects.map((project) => {
+                  const submitted = parseDate(project.submittedAt);
+                  const carpenterEmail = knownCarpenters.get(project.carpenterId) ?? project.carpenterId;
+
+                  return (
+                    <li
+                      key={project.id}
+                      className="rounded-2xl border border-black/10 bg-black/5 p-4 dark:border-white/10 dark:bg-white/5"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-black dark:text-white">
+                            {project.title}
+                          </p>
+                          <p className="text-xs uppercase tracking-wide text-black/60 dark:text-white/60">
+                            Carpenter: {carpenterEmail ?? "Unknown"}
+                          </p>
+                          {project.details ? (
+                            <p className="mt-1 text-sm/6 text-black/70 dark:text-white/70">
+                              {project.details}
+                            </p>
+                          ) : null}
+                        </div>
+                        <span className="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-800 dark:bg-emerald-400/10 dark:text-emerald-200">
+                          {project.status.replace(/_/g, " ")}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-xs uppercase tracking-wide text-black/50 dark:text-white/50">
+                        Submitted {formatDateTime(submitted)}
+                      </p>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="mt-4 text-sm/6 text-black/60 dark:text-white/60">
+                You haven&apos;t submitted any projects yet. Use the form above to share your first idea.
+              </p>
+            )}
+          </article>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { SupabaseEnvWarning } from "@/components/SupabaseEnvWarning";
+import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
+import { getInvitationDetails, acceptInvitation, type InvitationDetails } from "@/lib/invitations";
+import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
+
+export type InvitePageProps = {
+  params: { token: string };
+};
+
+export default function InvitePage({ params }: InvitePageProps) {
+  const router = useRouter();
+  const isSupabaseConfigured = isSupabaseConfiguredOnClient();
+  const supabase = useMemo(
+    () => (isSupabaseConfigured ? createSupabaseBrowserClient() : null),
+    [isSupabaseConfigured],
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [invitation, setInvitation] = useState<InvitationDetails | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [acceptError, setAcceptError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
+    let active = true;
+
+    const loadInvitation = async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const details = await getInvitationDetails(supabase, params.token);
+
+        if (!active) {
+          return;
+        }
+
+        setInvitation(details);
+
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (!active) {
+          return;
+        }
+
+        if (user) {
+          setIsAccepting(true);
+          setAcceptError(null);
+
+          try {
+            await acceptInvitation(supabase, params.token);
+
+            if (!active) {
+              return;
+            }
+
+            router.replace("/dashboard");
+            router.refresh();
+            return;
+          } catch (error) {
+            if (!active) {
+              return;
+            }
+
+            setAcceptError(
+              error instanceof Error
+                ? error.message
+                : "We couldn't accept this invitation.",
+            );
+          } finally {
+            if (active) {
+              setIsAccepting(false);
+            }
+          }
+        }
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "We couldn't validate this invitation.",
+        );
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadInvitation().catch(() => {
+      if (!active) {
+        return;
+      }
+
+      setErrorMessage("We couldn't validate this invitation.");
+      setIsLoading(false);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [params.token, router, supabase]);
+
+  if (!isSupabaseConfigured) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-16">
+        <SupabaseEnvWarning description="Add your Supabase credentials so invitation links can be validated." />
+      </div>
+    );
+  }
+
+  if (!supabase) {
+    return null;
+  }
+
+  const registerHref = `/auth/register?invitation=${encodeURIComponent(params.token)}&account=client`;
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-16">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Accept your invitation</h1>
+        <p className="text-sm/6 text-black/60 dark:text-white/60">
+          Securely join the carpenter who sent you this invitation.
+        </p>
+      </header>
+
+      {isLoading ? (
+        <div className="rounded-2xl border border-black/10 bg-white px-6 py-10 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+          <p className="text-sm/6 text-black/60 dark:text-white/60">Validating your invitation…</p>
+        </div>
+      ) : errorMessage ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 px-6 py-6 text-red-800 dark:border-red-400/60 dark:bg-red-400/10 dark:text-red-100">
+          <h2 className="text-lg font-semibold">Invitation unavailable</h2>
+          <p className="mt-2 text-sm/6">{errorMessage}</p>
+        </div>
+      ) : invitation ? (
+        <div className="space-y-6">
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Invitation details</h2>
+            <dl className="mt-4 space-y-3 text-sm/6 text-black/70 dark:text-white/70">
+              <div>
+                <dt className="font-medium text-black dark:text-white">Carpenter</dt>
+                <dd className="mt-1 break-all">
+                  {invitation.carpenterEmail ?? "Your carpenter"}
+                </dd>
+              </div>
+              <div>
+                <dt className="font-medium text-black dark:text-white">Invitation sent to</dt>
+                <dd className="mt-1 break-all">{invitation.invitedEmail}</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-black dark:text-white">Expires</dt>
+                <dd className="mt-1">
+                  {new Intl.DateTimeFormat(undefined, {
+                    dateStyle: "long",
+                    timeStyle: "short",
+                  }).format(new Date(invitation.expiresAt))}
+                </dd>
+              </div>
+            </dl>
+          </article>
+
+          {acceptError ? (
+            <div className="rounded-2xl border border-red-200 bg-red-50 px-6 py-4 text-red-800 dark:border-red-400/60 dark:bg-red-400/10 dark:text-red-100">
+              <h2 className="text-base font-semibold">We couldn&apos;t finish linking your account.</h2>
+              <p className="mt-1 text-sm/6">{acceptError}</p>
+            </div>
+          ) : null}
+
+          <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
+            <h2 className="text-lg font-semibold">Next steps</h2>
+            <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
+              Create a free client account or sign in to attach your profile to this carpenter.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <Link
+                className="inline-flex items-center justify-center rounded-md bg-black px-4 py-2 text-sm font-semibold text-white transition hover:bg-black/90 focus:outline-none focus:ring-2 focus:ring-black/20 dark:bg-white dark:text-black dark:hover:bg-white/90 dark:focus:ring-white/30"
+                href={registerHref}
+              >
+                Create your account
+              </Link>
+              <Link
+                className="inline-flex items-center justify-center rounded-md border border-black/10 px-4 py-2 text-sm font-medium text-black transition hover:border-black/20 hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:border-white/40 dark:hover:bg-white/10"
+                href="/auth/login"
+              >
+                Sign in
+              </Link>
+            </div>
+            {isAccepting ? (
+              <p className="mt-4 text-sm/6 text-black/60 dark:text-white/60">
+                Finalising the invitation with your signed-in account…
+              </p>
+            ) : null}
+          </article>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/carpenters.ts
+++ b/src/lib/carpenters.ts
@@ -1,0 +1,77 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { AvatarType } from "./avatar";
+
+export type CarpenterClient = {
+  clientId: string;
+  clientEmail: string | null;
+  avatarType: AvatarType | null;
+  avatarPath: string | null;
+};
+
+export type AssignedCarpenter = {
+  carpenterId: string;
+  carpenterEmail: string | null;
+  avatarType: AvatarType | null;
+  avatarPath: string | null;
+};
+
+export type ActiveCarpenter = {
+  carpenterId: string;
+  carpenterEmail: string | null;
+  avatarType: AvatarType | null;
+  avatarPath: string | null;
+  subscriptionExpiresAt: string | null;
+};
+
+export async function listCarpenterClients(supabase: SupabaseClient) {
+  const { data, error } = await supabase.rpc("list_carpenter_clients");
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((entry) => ({
+    clientId: entry.client_id as string,
+    clientEmail: (entry.client_email as string | null) ?? null,
+    avatarType: (entry.avatar_type as AvatarType | null) ?? null,
+    avatarPath: (entry.avatar_path as string | null) ?? null,
+  } satisfies CarpenterClient));
+}
+
+export async function getAssignedCarpenter(supabase: SupabaseClient) {
+  const { data, error } = await supabase.rpc("get_assigned_carpenter");
+
+  if (error) {
+    throw error;
+  }
+
+  const record = Array.isArray(data) ? data[0] : data;
+
+  if (!record) {
+    return null;
+  }
+
+  return {
+    carpenterId: record.carpenter_id as string,
+    carpenterEmail: (record.carpenter_email as string | null) ?? null,
+    avatarType: (record.avatar_type as AvatarType | null) ?? null,
+    avatarPath: (record.avatar_path as string | null) ?? null,
+  } satisfies AssignedCarpenter;
+}
+
+export async function listActiveCarpenters(supabase: SupabaseClient) {
+  const { data, error } = await supabase.rpc("list_active_carpenters");
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((record) => ({
+    carpenterId: record.carpenter_id as string,
+    carpenterEmail: (record.carpenter_email as string | null) ?? null,
+    avatarType: (record.avatar_type as AvatarType | null) ?? null,
+    avatarPath: (record.avatar_path as string | null) ?? null,
+    subscriptionExpiresAt: (record.subscription_expires_at as string | null) ?? null,
+  } satisfies ActiveCarpenter));
+}

--- a/src/lib/invitations.ts
+++ b/src/lib/invitations.ts
@@ -1,0 +1,90 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type InvitationDetails = {
+  token: string;
+  carpenterId: string;
+  carpenterEmail: string | null;
+  invitedEmail: string;
+  expiresAt: string;
+  acceptedAt: string | null;
+};
+
+export async function generateInvitation(
+  supabase: SupabaseClient,
+  carpenterId: string,
+  invitedEmail: string,
+  expiresAt: Date,
+) {
+  const { data, error } = await supabase
+    .from("carpenter_invitations")
+    .insert({
+      carpenter_id: carpenterId,
+      invited_email: invitedEmail,
+      expires_at: expiresAt.toISOString(),
+    })
+    .select("token, invited_email, expires_at, accepted_at")
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return {
+    token: data.token as string,
+    invitedEmail: data.invited_email as string,
+    expiresAt: data.expires_at as string,
+    acceptedAt: data.accepted_at as string | null,
+  };
+}
+
+export async function getInvitationDetails(
+  supabase: SupabaseClient,
+  token: string,
+): Promise<InvitationDetails> {
+  const { data, error } = await supabase.rpc("validate_carpenter_invitation", {
+    invitation_token: token,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  const record = Array.isArray(data) ? data[0] : data;
+
+  if (!record) {
+    throw new Error("Invitation is no longer available.");
+  }
+
+  return {
+    token: record.token as string,
+    carpenterId: record.carpenter_id as string,
+    carpenterEmail: (record.carpenter_email as string | null) ?? null,
+    invitedEmail: record.invited_email as string,
+    expiresAt: record.expires_at as string,
+    acceptedAt: record.accepted_at as string | null,
+  };
+}
+
+export async function acceptInvitation(
+  supabase: SupabaseClient,
+  token: string,
+) {
+  const { data, error } = await supabase.rpc("accept_carpenter_invitation", {
+    invitation_token: token,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  const record = Array.isArray(data) ? data[0] : data;
+
+  if (!record) {
+    return null;
+  }
+
+  return {
+    carpenterId: record.carpenter_id as string,
+    clientId: record.client_id as string,
+  };
+}

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type ProjectRecord = {
+  id: string;
+  carpenterId: string;
+  clientId: string;
+  title: string;
+  details: string | null;
+  status: string;
+  submittedAt: string;
+  updatedAt: string | null;
+};
+
+export async function submitProjectBrief(
+  supabase: SupabaseClient,
+  carpenterId: string,
+  title: string,
+  details: string,
+) {
+  const { data, error } = await supabase.rpc("submit_project_brief", {
+    target_carpenter: carpenterId,
+    project_title: title,
+    project_details: details,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  const record = Array.isArray(data) ? data[0] : data;
+
+  if (!record) {
+    throw new Error("Project submission failed.");
+  }
+
+  return {
+    id: record.project_id as string,
+    carpenterId: record.carpenter_id as string,
+    clientId: record.client_id as string,
+    status: record.status as string,
+    submittedAt: record.submitted_at as string,
+  };
+}
+
+export async function fetchProjectsForCarpenter(
+  supabase: SupabaseClient,
+  carpenterId: string,
+) {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, carpenter_id, client_id, title, details, status, submitted_at, updated_at")
+    .eq("carpenter_id", carpenterId)
+    .order("submitted_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((record) => ({
+    id: record.id as string,
+    carpenterId: record.carpenter_id as string,
+    clientId: record.client_id as string,
+    title: record.title as string,
+    details: (record.details as string | null) ?? null,
+    status: record.status as string,
+    submittedAt: record.submitted_at as string,
+    updatedAt: (record.updated_at as string | null) ?? null,
+  } satisfies ProjectRecord));
+}
+
+export async function fetchProjectsForClient(
+  supabase: SupabaseClient,
+  clientId: string,
+) {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, carpenter_id, client_id, title, details, status, submitted_at, updated_at")
+    .eq("client_id", clientId)
+    .order("submitted_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((record) => ({
+    id: record.id as string,
+    carpenterId: record.carpenter_id as string,
+    clientId: record.client_id as string,
+    title: record.title as string,
+    details: (record.details as string | null) ?? null,
+    status: record.status as string,
+    submittedAt: record.submitted_at as string,
+    updatedAt: (record.updated_at as string | null) ?? null,
+  } satisfies ProjectRecord));
+}

--- a/supabase/migrations/0004_projects_and_collaboration_updates.sql
+++ b/supabase/migrations/0004_projects_and_collaboration_updates.sql
@@ -1,0 +1,458 @@
+-- Synchronize collaboration tables, invitation helpers, and project submission flows.
+
+-- Rename legacy carpenter_projects table to a shared projects table.
+alter table if exists public.carpenter_projects
+  rename to projects;
+
+alter index if exists carpenter_projects_carpenter_id_idx
+  rename to projects_carpenter_id_idx;
+
+alter index if exists carpenter_projects_client_id_idx
+  rename to projects_client_id_idx;
+
+-- Ensure the projects table matches the collaboration requirements.
+create type if not exists public.project_status as enum ('submitted', 'in_progress', 'completed');
+
+alter table if exists public.projects
+  add column if not exists title text not null default 'New project';
+
+alter table if exists public.projects
+  add column if not exists details text;
+
+alter table if exists public.projects
+  add column if not exists status public.project_status not null default 'submitted';
+
+alter table if exists public.projects
+  add column if not exists submitted_by uuid references public.profiles(id);
+
+alter table if exists public.projects
+  add column if not exists submitted_at timestamptz not null default timezone('utc', now());
+
+alter table if exists public.projects
+  add column if not exists updated_at timestamptz not null default timezone('utc', now());
+
+-- Clean up defaults that are only used to backfill data.
+alter table if exists public.projects
+  alter column title drop default;
+
+alter table if exists public.projects
+  alter column status set default 'submitted';
+
+create index if not exists projects_submitted_at_idx
+  on public.projects (submitted_at desc);
+
+-- Default and update triggers for projects.
+create or replace function public.projects_set_defaults()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.submitted_at is null then
+    new.submitted_at := timezone('utc', now());
+  end if;
+
+  if new.updated_at is null then
+    new.updated_at := timezone('utc', now());
+  end if;
+
+  if new.status is null then
+    new.status := 'submitted';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.projects_touch_updated_at()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  new.updated_at := timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists projects_set_defaults on public.projects;
+create trigger projects_set_defaults
+  before insert on public.projects
+  for each row execute function public.projects_set_defaults();
+
+drop trigger if exists projects_touch_updated_at on public.projects;
+create trigger projects_touch_updated_at
+  before update on public.projects
+  for each row execute function public.projects_touch_updated_at();
+
+-- Refresh RLS policies for projects so only participants have access.
+alter table if exists public.projects enable row level security;
+
+drop policy if exists "Carpenters and clients view shared projects" on public.projects;
+drop policy if exists "Carpenters create shared projects" on public.projects;
+drop policy if exists "Carpenters update shared projects" on public.projects;
+drop policy if exists "Carpenters delete shared projects" on public.projects;
+
+drop policy if exists "Clients update shared projects" on public.projects;
+
+drop policy if exists "Clients submit projects" on public.projects;
+
+drop policy if exists "Participants view their projects" on public.projects;
+drop policy if exists "Participants manage their projects" on public.projects;
+
+create policy if not exists "Participants view their projects"
+  on public.projects
+  for select
+  using (
+    carpenter_id = auth.uid()
+    or client_id = auth.uid()
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.account_type = 'admin'
+    )
+  );
+
+create policy if not exists "Carpenters create projects"
+  on public.projects
+  for insert
+  with check (
+    carpenter_id = auth.uid()
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.account_type in ('carpenter', 'admin')
+    )
+  );
+
+create policy if not exists "Carpenters update their projects"
+  on public.projects
+  for update
+  using (
+    carpenter_id = auth.uid()
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.account_type = 'admin'
+    )
+  )
+  with check (
+    carpenter_id = auth.uid()
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.account_type = 'admin'
+    )
+  );
+
+create policy if not exists "Carpenters delete their projects"
+  on public.projects
+  for delete
+  using (
+    carpenter_id = auth.uid()
+    or exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.account_type = 'admin'
+    )
+  );
+
+-- Allow clients to submit project briefs through a helper function while keeping direct inserts scoped to carpenters.
+
+-- Invitation validation helper that is callable without authentication.
+create or replace function public.validate_carpenter_invitation(invitation_token uuid)
+returns table (
+  token uuid,
+  carpenter_id uuid,
+  carpenter_email text,
+  invited_email text,
+  expires_at timestamptz,
+  accepted_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  invitation_record public.carpenter_invitations%rowtype;
+  carpenter_email text;
+begin
+  select *
+  into invitation_record
+  from public.carpenter_invitations
+  where token = invitation_token
+  limit 1;
+
+  if not found then
+    raise exception 'Invitation not found';
+  end if;
+
+  if invitation_record.expires_at <= timezone('utc', now()) then
+    raise exception 'Invitation expired';
+  end if;
+
+  select email
+  into carpenter_email
+  from auth.users
+  where id = invitation_record.carpenter_id
+  limit 1;
+
+  return query
+  select
+    invitation_record.token,
+    invitation_record.carpenter_id,
+    carpenter_email,
+    invitation_record.invited_email,
+    invitation_record.expires_at,
+    invitation_record.accepted_at;
+end;
+$$;
+
+grant execute on function public.validate_carpenter_invitation(invitation_token uuid) to anon, authenticated;
+
+-- Accept an invitation and ensure the client is linked to the carpenter.
+create or replace function public.accept_carpenter_invitation(invitation_token uuid)
+returns table (
+  carpenter_id uuid,
+  client_id uuid
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  invitation_record public.carpenter_invitations%rowtype;
+  current_client uuid;
+begin
+  current_client := auth.uid();
+
+  if current_client is null then
+    raise exception 'You must be signed in to accept an invitation.';
+  end if;
+
+  select *
+  into invitation_record
+  from public.carpenter_invitations
+  where token = invitation_token
+  for update;
+
+  if not found then
+    raise exception 'Invitation not found';
+  end if;
+
+  if invitation_record.accepted_at is not null then
+    return query
+    select invitation_record.carpenter_id, current_client;
+  end if;
+
+  if invitation_record.expires_at <= timezone('utc', now()) then
+    raise exception 'Invitation expired';
+  end if;
+
+  insert into public.carpenter_clients (carpenter_id, client_id)
+  values (invitation_record.carpenter_id, current_client)
+  on conflict (carpenter_id, client_id) do nothing;
+
+  update public.carpenter_invitations
+  set accepted_at = timezone('utc', now())
+  where token = invitation_token;
+
+  return query
+  select invitation_record.carpenter_id, current_client;
+end;
+$$;
+
+grant execute on function public.accept_carpenter_invitation(invitation_token uuid) to authenticated;
+
+-- Helper listing for carpenters to see their assigned clients with contact data.
+create or replace function public.list_carpenter_clients()
+returns table (
+  client_id uuid,
+  client_email text,
+  avatar_type text,
+  avatar_path text
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    cc.client_id,
+    au.email as client_email,
+    p.avatar_type,
+    p.avatar_path
+  from public.carpenter_clients cc
+  join public.profiles p
+    on p.id = cc.client_id
+  join auth.users au
+    on au.id = cc.client_id
+  where cc.carpenter_id = auth.uid();
+$$;
+
+grant execute on function public.list_carpenter_clients() to authenticated;
+
+-- Helper for clients to fetch their assigned carpenter contact data.
+create or replace function public.get_assigned_carpenter()
+returns table (
+  carpenter_id uuid,
+  carpenter_email text,
+  avatar_type text,
+  avatar_path text
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    cc.carpenter_id,
+    au.email as carpenter_email,
+    p.avatar_type,
+    p.avatar_path
+  from public.carpenter_clients cc
+  join public.profiles p
+    on p.id = cc.carpenter_id
+  join auth.users au
+    on au.id = cc.carpenter_id
+  where cc.client_id = auth.uid()
+  limit 1;
+$$;
+
+grant execute on function public.get_assigned_carpenter() to authenticated;
+
+-- Directory for clients to browse active carpenters.
+create or replace function public.list_active_carpenters()
+returns table (
+  carpenter_id uuid,
+  carpenter_email text,
+  avatar_type text,
+  avatar_path text,
+  subscription_expires_at timestamptz
+)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    p.id as carpenter_id,
+    au.email as carpenter_email,
+    p.avatar_type,
+    p.avatar_path,
+    p.subscription_expires_at
+  from public.profiles p
+  join auth.users au
+    on au.id = p.id
+  where p.account_type = 'carpenter'
+    and p.subscription_expires_at > timezone('utc', now());
+$$;
+
+grant execute on function public.list_active_carpenters() to authenticated;
+
+-- Allow clients to submit project briefs and automatically create the assignment link.
+create or replace function public.submit_project_brief(
+  target_carpenter uuid,
+  project_title text,
+  project_details text
+)
+returns table (
+  project_id uuid,
+  carpenter_id uuid,
+  client_id uuid,
+  status public.project_status,
+  submitted_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  current_client uuid;
+  carpenter_record public.profiles%rowtype;
+  inserted_project public.projects%rowtype;
+begin
+  current_client := auth.uid();
+
+  if current_client is null then
+    raise exception 'You must be signed in to submit a project.';
+  end if;
+
+  select *
+  into carpenter_record
+  from public.profiles
+  where id = target_carpenter
+    and account_type = 'carpenter'
+    and subscription_expires_at > timezone('utc', now())
+  limit 1;
+
+  if not found then
+    raise exception 'Selected carpenter is unavailable.';
+  end if;
+
+  insert into public.carpenter_clients (carpenter_id, client_id)
+  values (target_carpenter, current_client)
+  on conflict (carpenter_id, client_id) do nothing;
+
+  insert into public.projects (carpenter_id, client_id, submitted_by, title, details)
+  values (target_carpenter, current_client, current_client, coalesce(project_title, 'Project brief'), project_details)
+  returning * into inserted_project;
+
+  return query
+  select inserted_project.id, inserted_project.carpenter_id, inserted_project.client_id, inserted_project.status, inserted_project.submitted_at;
+end;
+$$;
+
+grant execute on function public.submit_project_brief(target_carpenter uuid, project_title text, project_details text) to authenticated;
+
+-- Expand profile policies so collaborators can view relevant information.
+drop policy if exists "Profiles are readable by their owner" on public.profiles;
+create policy if not exists "Profiles are readable by their owner"
+  on public.profiles
+  for select
+  using (auth.uid() = id);
+
+create policy if not exists "Carpenters view assigned clients"
+  on public.profiles
+  for select
+  using (
+    auth.uid() = id
+    or exists (
+      select 1
+      from public.carpenter_clients cc
+      where cc.carpenter_id = auth.uid()
+        and cc.client_id = public.profiles.id
+    )
+  );
+
+create policy if not exists "Clients view assigned carpenter"
+  on public.profiles
+  for select
+  using (
+    auth.uid() = id
+    or exists (
+      select 1
+      from public.carpenter_clients cc
+      where cc.client_id = auth.uid()
+        and cc.carpenter_id = public.profiles.id
+    )
+  );
+
+create policy if not exists "Authenticated users can view active carpenters"
+  on public.profiles
+  for select
+  using (
+    auth.uid() is not null
+    and account_type = 'carpenter'
+    and subscription_expires_at > timezone('utc', now())
+  );
+
+-- Ensure update policies still prevent privilege escalation.
+create policy if not exists "Profiles are updatable by their owner"
+  on public.profiles
+  for update
+  using (auth.uid() = id);


### PR DESCRIPTION
## Summary
- extend the dashboard with role-aware collaboration tooling including invitation creation, pending invite management, assigned client overviews, and client project submissions
- add an invitation landing page that validates tokens, links signed-in clients, and forwards newcomers to registration with the correct role preselected
- update Supabase schema and helpers to expose the shared projects table, invitation RPC helpers, directory listings, and project brief submission routine for carpenters and clients
- add browser-side helpers for invitations, carpenters, and projects plus honor invitation-forced account types during registration

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cb158f76208322ac44fa741d32e152