### PR TITLE
Provision avatar bucket without storage.create_bucket

### DIFF
--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -560,7 +560,7 @@ Once the script is applied, create an account through the app. A matching `publi
 
 ## 3. Provision the Storage bucket for avatars
 
-Profiles now track whether an avatar is a built-in icon or a file stored in Supabase Storage. Create a private `avatars` bucket and policies that allow each user to manage their own files:
+Profiles now track whether an avatar is a built-in icon or a file stored in Supabase Storage. Create a private `avatars` bucket and policies that allow each user to manage their own files. The bucket is inserted directly because some Supabase instances (including self-hosted deployments and older projects) do not expose the `storage.create_bucket` helper, which would otherwise trigger the `42883` error:
 
 ```sql
 insert into storage.buckets (id, name, public)
@@ -604,4 +604,4 @@ create policy "Avatar files are removable by their owner"
   );
 ```
 
-> ℹ️ Supabase projects without the `storage.create_bucket` helper (self-hosted deployments, older instances, etc.) can still provision the bucket with the `insert … on conflict do nothing` statement above. Dropping and recreating each policy keeps the Storage permissions idempotent as well.
+> ℹ️ If you've previously run `select storage.create_bucket('avatars', false);`, replace it with the `insert … on conflict do nothing` statement above. The direct insert succeeds even when the helper is unavailable and the `on conflict` clause keeps the bucket creation idempotent alongside the drop-and-create policy pattern.

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -60,15 +60,16 @@ alter table public.profiles enable row level security;
 create index if not exists profiles_subscription_expires_at_idx
   on public.profiles (subscription_expires_at);
 
--- Ensure every signed-in user can read their own profile row.
-create policy if not exists "Profiles are readable by their owner"
+drop policy if exists "Profiles are readable by their owner" on public.profiles;
+create policy "Profiles are readable by their owner"
   on public.profiles
   for select
   using (auth.uid() = id);
 
 -- Allow future profile columns to be updated by the owner while
 -- a trigger (defined below) keeps the subscription timestamp locked down.
-create policy if not exists "Profiles are updatable by their owner"
+drop policy if exists "Profiles are updatable by their owner" on public.profiles;
+create policy "Profiles are updatable by their owner"
   on public.profiles
   for update
   using (auth.uid() = id);
@@ -219,7 +220,8 @@ alter table public.carpenter_clients enable row level security;
 alter table public.carpenter_projects enable row level security;
 
 -- Policies for carpenter invitations.
-create policy if not exists "Carpenters view their invitations"
+drop policy if exists "Carpenters view their invitations" on public.carpenter_invitations;
+create policy "Carpenters view their invitations"
   on public.carpenter_invitations
   for select
   using (
@@ -240,7 +242,8 @@ create policy if not exists "Carpenters view their invitations"
     )
   );
 
-create policy if not exists "Carpenters create invitations"
+drop policy if exists "Carpenters create invitations" on public.carpenter_invitations;
+create policy "Carpenters create invitations"
   on public.carpenter_invitations
   for insert
   with check (
@@ -261,7 +264,8 @@ create policy if not exists "Carpenters create invitations"
     )
   );
 
-create policy if not exists "Carpenters update their invitations"
+drop policy if exists "Carpenters update their invitations" on public.carpenter_invitations;
+create policy "Carpenters update their invitations"
   on public.carpenter_invitations
   for update
   using (
@@ -299,7 +303,8 @@ create policy if not exists "Carpenters update their invitations"
     )
   );
 
-create policy if not exists "Carpenters delete their invitations"
+drop policy if exists "Carpenters delete their invitations" on public.carpenter_invitations;
+create policy "Carpenters delete their invitations"
   on public.carpenter_invitations
   for delete
   using (
@@ -321,7 +326,8 @@ create policy if not exists "Carpenters delete their invitations"
   );
 
 -- Policies for carpenter/client links.
-create policy if not exists "Carpenters and clients view their link"
+drop policy if exists "Carpenters and clients view their link" on public.carpenter_clients;
+create policy "Carpenters and clients view their link"
   on public.carpenter_clients
   for select
   using (
@@ -343,7 +349,8 @@ create policy if not exists "Carpenters and clients view their link"
     )
   );
 
-create policy if not exists "Carpenters manage their client links"
+drop policy if exists "Carpenters manage their client links" on public.carpenter_clients;
+create policy "Carpenters manage their client links"
   on public.carpenter_clients
   for insert
   with check (
@@ -364,7 +371,8 @@ create policy if not exists "Carpenters manage their client links"
     )
   );
 
-create policy if not exists "Carpenters update their client links"
+drop policy if exists "Carpenters update their client links" on public.carpenter_clients;
+create policy "Carpenters update their client links"
   on public.carpenter_clients
   for update
   using (
@@ -402,7 +410,8 @@ create policy if not exists "Carpenters update their client links"
     )
   );
 
-create policy if not exists "Carpenters remove their client links"
+drop policy if exists "Carpenters remove their client links" on public.carpenter_clients;
+create policy "Carpenters remove their client links"
   on public.carpenter_clients
   for delete
   using (
@@ -424,7 +433,8 @@ create policy if not exists "Carpenters remove their client links"
   );
 
 -- Policies for shared projects.
-create policy if not exists "Carpenters and clients view shared projects"
+drop policy if exists "Carpenters and clients view shared projects" on public.carpenter_projects;
+create policy "Carpenters and clients view shared projects"
   on public.carpenter_projects
   for select
   using (
@@ -446,7 +456,8 @@ create policy if not exists "Carpenters and clients view shared projects"
     )
   );
 
-create policy if not exists "Carpenters create shared projects"
+drop policy if exists "Carpenters create shared projects" on public.carpenter_projects;
+create policy "Carpenters create shared projects"
   on public.carpenter_projects
   for insert
   with check (
@@ -467,7 +478,8 @@ create policy if not exists "Carpenters create shared projects"
     )
   );
 
-create policy if not exists "Carpenters update shared projects"
+drop policy if exists "Carpenters update shared projects" on public.carpenter_projects;
+create policy "Carpenters update shared projects"
   on public.carpenter_projects
   for update
   using (
@@ -505,7 +517,8 @@ create policy if not exists "Carpenters update shared projects"
     )
   );
 
-create policy if not exists "Carpenters delete shared projects"
+drop policy if exists "Carpenters delete shared projects" on public.carpenter_projects;
+create policy "Carpenters delete shared projects"
   on public.carpenter_projects
   for delete
   using (
@@ -541,7 +554,7 @@ If you prefer using migrations:
    supabase db push
    ```
 
-The CLI will run every SQL file in [`supabase/migrations`](../supabase/migrations) (including the new account-type migration `0003_add_account_type_and_carpenter_tables.sql`) against the linked project.
+The CLI will run every SQL file in [`supabase/migrations`](../supabase/migrations) (including the new account-type migration `0003_add_account_type_and_carpenter_tables.sql` and the avatar bucket provisioning script `0005_provision_avatar_bucket.sql`) against the linked project.
 
 Once the script is applied, create an account through the app. A matching `public.profiles` row will be created automatically with a trial `subscription_expires_at`, letting the dashboard render the subscription warning banners correctly. Carpenters can invite clients and track shared projects immediately after provisioning.
 
@@ -550,23 +563,28 @@ Once the script is applied, create an account through the app. A matching `publi
 Profiles now track whether an avatar is a built-in icon or a file stored in Supabase Storage. Create a private `avatars` bucket and policies that allow each user to manage their own files:
 
 ```sql
-select storage.create_bucket('avatars', jsonb_build_object('public', false));
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', false)
+on conflict (id) do nothing;
 
-create policy if not exists "Avatar files are readable by their owner"
+drop policy if exists "Avatar files are readable by their owner" on storage.objects;
+create policy "Avatar files are readable by their owner"
   on storage.objects for select
   using (
     bucket_id = 'avatars'
     and auth.uid() = owner
   );
 
-create policy if not exists "Avatar files are uploaded by their owner"
+drop policy if exists "Avatar files are uploaded by their owner" on storage.objects;
+create policy "Avatar files are uploaded by their owner"
   on storage.objects for insert
   with check (
     bucket_id = 'avatars'
     and auth.uid() = owner
   );
 
-create policy if not exists "Avatar files are replaceable by their owner"
+drop policy if exists "Avatar files are replaceable by their owner" on storage.objects;
+create policy "Avatar files are replaceable by their owner"
   on storage.objects for update
   using (
     bucket_id = 'avatars'
@@ -577,7 +595,8 @@ create policy if not exists "Avatar files are replaceable by their owner"
     and auth.uid() = owner
   );
 
-create policy if not exists "Avatar files are removable by their owner"
+drop policy if exists "Avatar files are removable by their owner" on storage.objects;
+create policy "Avatar files are removable by their owner"
   on storage.objects for delete
   using (
     bucket_id = 'avatars'
@@ -585,4 +604,4 @@ create policy if not exists "Avatar files are removable by their owner"
   );
 ```
 
-> ℹ️ If you rerun the SQL after the bucket already exists, Supabase will ignore the `create_bucket` call. The `if not exists` guards keep the Storage policies idempotent as well.
+> ℹ️ Supabase projects without the `storage.create_bucket` helper (self-hosted deployments, older instances, etc.) can still provision the bucket with the `insert … on conflict do nothing` statement above. Dropping and recreating each policy keeps the Storage permissions idempotent as well.

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -563,6 +563,9 @@ Once the script is applied, create an account through the app. A matching `publi
 Profiles now track whether an avatar is a built-in icon or a file stored in Supabase Storage. Create a private `avatars` bucket and policies that allow each user to manage their own files. The bucket is inserted directly because some Supabase instances (including self-hosted deployments and older projects) do not expose the `storage.create_bucket` helper, which would otherwise trigger the `42883` error. The `on conflict` clause keeps reruns idempotent and corrects the bucket metadata if it already exists:
 
 ```sql
+-- ⚠️ Keep this direct insert. Older/self-hosted Supabase instances do not expose
+--    storage.create_bucket(..) and will raise ERROR 42883 if that helper is
+--    called.
 insert into storage.buckets (id, name, public)
 values ('avatars', 'avatars', false)
 on conflict (id) do update
@@ -607,4 +610,8 @@ create policy "Avatar files are removable by their owner"
   );
 ```
 
-> ❗️ If an earlier script (or an auto-merge) left `select storage.create_bucket('avatars', false);` in place, delete that line before rerunning this block. The helper is missing on some Supabase projects and will keep throwing `ERROR: 42883: function storage.create_bucket(unknown, boolean) does not exist` until it is removed.
+> ❗️ If a previous run or merge still left a `storage.create_bucket` call in your
+> migration history, delete that statement before applying this block. The
+> helper is absent on some Supabase projects and will continue to raise
+> `ERROR: 42883: function storage.create_bucket(unknown, boolean) does not exist`
+> whenever it executes.

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -560,12 +560,15 @@ Once the script is applied, create an account through the app. A matching `publi
 
 ## 3. Provision the Storage bucket for avatars
 
-Profiles now track whether an avatar is a built-in icon or a file stored in Supabase Storage. Create a private `avatars` bucket and policies that allow each user to manage their own files. The bucket is inserted directly because some Supabase instances (including self-hosted deployments and older projects) do not expose the `storage.create_bucket` helper, which would otherwise trigger the `42883` error:
+Profiles now track whether an avatar is a built-in icon or a file stored in Supabase Storage. Create a private `avatars` bucket and policies that allow each user to manage their own files. The bucket is inserted directly because some Supabase instances (including self-hosted deployments and older projects) do not expose the `storage.create_bucket` helper, which would otherwise trigger the `42883` error. The `on conflict` clause keeps reruns idempotent and corrects the bucket metadata if it already exists:
 
 ```sql
 insert into storage.buckets (id, name, public)
 values ('avatars', 'avatars', false)
-on conflict (id) do nothing;
+on conflict (id) do update
+set
+  name = excluded.name,
+  public = excluded.public;
 
 drop policy if exists "Avatar files are readable by their owner" on storage.objects;
 create policy "Avatar files are readable by their owner"
@@ -604,6 +607,4 @@ create policy "Avatar files are removable by their owner"
   );
 ```
 
-> ℹ️ If you've previously run `select storage.create_bucket('avatars', false);`, replace it with the `insert … on conflict do nothing` statement above. The direct insert succeeds even when the helper is unavailable and the `on conflict` clause keeps the bucket creation idempotent alongside the drop-and-create policy pattern.
->
-> ❗️ Seeing `ERROR: 42883: function storage.create_bucket(unknown, boolean) does not exist` usually means an older helper call is still in your script. Remove that `select storage.create_bucket(...)` line and rerun the insert so Supabase stops raising the error.
+> ❗️ If an earlier script (or an auto-merge) left `select storage.create_bucket('avatars', false);` in place, delete that line before rerunning this block. The helper is missing on some Supabase projects and will keep throwing `ERROR: 42883: function storage.create_bucket(unknown, boolean) does not exist` until it is removed.

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -605,3 +605,5 @@ create policy "Avatar files are removable by their owner"
 ```
 
 > ℹ️ If you've previously run `select storage.create_bucket('avatars', false);`, replace it with the `insert … on conflict do nothing` statement above. The direct insert succeeds even when the helper is unavailable and the `on conflict` clause keeps the bucket creation idempotent alongside the drop-and-create policy pattern.
+>
+> ❗️ Seeing `ERROR: 42883: function storage.create_bucket(unknown, boolean) does not exist` usually means an older helper call is still in your script. Remove that `select storage.create_bucket(...)` line and rerun the insert so Supabase stops raising the error.

--- a/supabase/migrations/0001_create_profiles.sql
+++ b/supabase/migrations/0001_create_profiles.sql
@@ -11,12 +11,14 @@ alter table public.profiles enable row level security;
 create index if not exists profiles_subscription_expires_at_idx
   on public.profiles (subscription_expires_at);
 
-create policy if not exists "Profiles are readable by their owner"
+drop policy if exists "Profiles are readable by their owner" on public.profiles;
+create policy "Profiles are readable by their owner"
   on public.profiles
   for select
   using (auth.uid() = id);
 
-create policy if not exists "Profiles are updatable by their owner"
+drop policy if exists "Profiles are updatable by their owner" on public.profiles;
+create policy "Profiles are updatable by their owner"
   on public.profiles
   for update
   using (auth.uid() = id);

--- a/supabase/migrations/0003_add_account_type_and_carpenter_tables.sql
+++ b/supabase/migrations/0003_add_account_type_and_carpenter_tables.sql
@@ -142,7 +142,8 @@ alter table public.carpenter_clients enable row level security;
 alter table public.carpenter_projects enable row level security;
 
 -- Policies for carpenter_invitations.
-create policy if not exists "Carpenters view their invitations"
+drop policy if exists "Carpenters view their invitations" on public.carpenter_invitations;
+create policy "Carpenters view their invitations"
   on public.carpenter_invitations
   for select
   using (
@@ -163,7 +164,8 @@ create policy if not exists "Carpenters view their invitations"
     )
   );
 
-create policy if not exists "Carpenters create invitations"
+drop policy if exists "Carpenters create invitations" on public.carpenter_invitations;
+create policy "Carpenters create invitations"
   on public.carpenter_invitations
   for insert
   with check (
@@ -184,7 +186,8 @@ create policy if not exists "Carpenters create invitations"
     )
   );
 
-create policy if not exists "Carpenters update their invitations"
+drop policy if exists "Carpenters update their invitations" on public.carpenter_invitations;
+create policy "Carpenters update their invitations"
   on public.carpenter_invitations
   for update
   using (
@@ -222,7 +225,8 @@ create policy if not exists "Carpenters update their invitations"
     )
   );
 
-create policy if not exists "Carpenters delete their invitations"
+drop policy if exists "Carpenters delete their invitations" on public.carpenter_invitations;
+create policy "Carpenters delete their invitations"
   on public.carpenter_invitations
   for delete
   using (
@@ -244,7 +248,8 @@ create policy if not exists "Carpenters delete their invitations"
   );
 
 -- Policies for carpenter/client links.
-create policy if not exists "Carpenters and clients view their link"
+drop policy if exists "Carpenters and clients view their link" on public.carpenter_clients;
+create policy "Carpenters and clients view their link"
   on public.carpenter_clients
   for select
   using (
@@ -266,7 +271,8 @@ create policy if not exists "Carpenters and clients view their link"
     )
   );
 
-create policy if not exists "Carpenters manage their client links"
+drop policy if exists "Carpenters manage their client links" on public.carpenter_clients;
+create policy "Carpenters manage their client links"
   on public.carpenter_clients
   for insert
   with check (
@@ -287,7 +293,8 @@ create policy if not exists "Carpenters manage their client links"
     )
   );
 
-create policy if not exists "Carpenters update their client links"
+drop policy if exists "Carpenters update their client links" on public.carpenter_clients;
+create policy "Carpenters update their client links"
   on public.carpenter_clients
   for update
   using (
@@ -325,7 +332,8 @@ create policy if not exists "Carpenters update their client links"
     )
   );
 
-create policy if not exists "Carpenters remove their client links"
+drop policy if exists "Carpenters remove their client links" on public.carpenter_clients;
+create policy "Carpenters remove their client links"
   on public.carpenter_clients
   for delete
   using (
@@ -347,7 +355,8 @@ create policy if not exists "Carpenters remove their client links"
   );
 
 -- Policies for shared projects.
-create policy if not exists "Carpenters and clients view shared projects"
+drop policy if exists "Carpenters and clients view shared projects" on public.carpenter_projects;
+create policy "Carpenters and clients view shared projects"
   on public.carpenter_projects
   for select
   using (
@@ -369,7 +378,8 @@ create policy if not exists "Carpenters and clients view shared projects"
     )
   );
 
-create policy if not exists "Carpenters create shared projects"
+drop policy if exists "Carpenters create shared projects" on public.carpenter_projects;
+create policy "Carpenters create shared projects"
   on public.carpenter_projects
   for insert
   with check (
@@ -390,7 +400,8 @@ create policy if not exists "Carpenters create shared projects"
     )
   );
 
-create policy if not exists "Carpenters update shared projects"
+drop policy if exists "Carpenters update shared projects" on public.carpenter_projects;
+create policy "Carpenters update shared projects"
   on public.carpenter_projects
   for update
   using (
@@ -428,7 +439,8 @@ create policy if not exists "Carpenters update shared projects"
     )
   );
 
-create policy if not exists "Carpenters delete shared projects"
+drop policy if exists "Carpenters delete shared projects" on public.carpenter_projects;
+create policy "Carpenters delete shared projects"
   on public.carpenter_projects
   for delete
   using (

--- a/supabase/migrations/0004_projects_and_collaboration_updates.sql
+++ b/supabase/migrations/0004_projects_and_collaboration_updates.sql
@@ -99,10 +99,10 @@ drop policy if exists "Clients update shared projects" on public.projects;
 
 drop policy if exists "Clients submit projects" on public.projects;
 
-drop policy if exists "Participants view their projects" on public.projects;
 drop policy if exists "Participants manage their projects" on public.projects;
 
-create policy if not exists "Participants view their projects"
+drop policy if exists "Participants view their projects" on public.projects;
+create policy "Participants view their projects"
   on public.projects
   for select
   using (
@@ -116,7 +116,8 @@ create policy if not exists "Participants view their projects"
     )
   );
 
-create policy if not exists "Carpenters create projects"
+drop policy if exists "Carpenters create projects" on public.projects;
+create policy "Carpenters create projects"
   on public.projects
   for insert
   with check (
@@ -129,7 +130,8 @@ create policy if not exists "Carpenters create projects"
     )
   );
 
-create policy if not exists "Carpenters update their projects"
+drop policy if exists "Carpenters update their projects" on public.projects;
+create policy "Carpenters update their projects"
   on public.projects
   for update
   using (
@@ -151,7 +153,8 @@ create policy if not exists "Carpenters update their projects"
     )
   );
 
-create policy if not exists "Carpenters delete their projects"
+drop policy if exists "Carpenters delete their projects" on public.projects;
+create policy "Carpenters delete their projects"
   on public.projects
   for delete
   using (
@@ -411,12 +414,13 @@ grant execute on function public.submit_project_brief(target_carpenter uuid, pro
 
 -- Expand profile policies so collaborators can view relevant information.
 drop policy if exists "Profiles are readable by their owner" on public.profiles;
-create policy if not exists "Profiles are readable by their owner"
+create policy "Profiles are readable by their owner"
   on public.profiles
   for select
   using (auth.uid() = id);
 
-create policy if not exists "Carpenters view assigned clients"
+drop policy if exists "Carpenters view assigned clients" on public.profiles;
+create policy "Carpenters view assigned clients"
   on public.profiles
   for select
   using (
@@ -429,7 +433,8 @@ create policy if not exists "Carpenters view assigned clients"
     )
   );
 
-create policy if not exists "Clients view assigned carpenter"
+drop policy if exists "Clients view assigned carpenter" on public.profiles;
+create policy "Clients view assigned carpenter"
   on public.profiles
   for select
   using (
@@ -442,7 +447,8 @@ create policy if not exists "Clients view assigned carpenter"
     )
   );
 
-create policy if not exists "Authenticated users can view active carpenters"
+drop policy if exists "Authenticated users can view active carpenters" on public.profiles;
+create policy "Authenticated users can view active carpenters"
   on public.profiles
   for select
   using (
@@ -452,7 +458,8 @@ create policy if not exists "Authenticated users can view active carpenters"
   );
 
 -- Ensure update policies still prevent privilege escalation.
-create policy if not exists "Profiles are updatable by their owner"
+drop policy if exists "Profiles are updatable by their owner" on public.profiles;
+create policy "Profiles are updatable by their owner"
   on public.profiles
   for update
   using (auth.uid() = id);

--- a/supabase/migrations/0005_provision_avatar_bucket.sql
+++ b/supabase/migrations/0005_provision_avatar_bucket.sql
@@ -1,4 +1,5 @@
--- Provision the avatars Storage bucket and policies.
+-- Provision the avatars Storage bucket and policies without relying on the
+-- storage.create_bucket helper, which is missing on some Supabase instances.
 insert into storage.buckets (id, name, public)
 values ('avatars', 'avatars', false)
 on conflict (id) do nothing;

--- a/supabase/migrations/0005_provision_avatar_bucket.sql
+++ b/supabase/migrations/0005_provision_avatar_bucket.sql
@@ -2,6 +2,8 @@
 -- storage.create_bucket helper, which is missing on some Supabase instances
 -- and would otherwise raise the 42883 "function storage.create_bucket does not
 -- exist" error.
+-- ⚠️ Do not replace this insert with a call to storage.create_bucket(..);
+--    older/self-hosted stacks omit that helper entirely.
 insert into storage.buckets (id, name, public)
 values ('avatars', 'avatars', false)
 on conflict (id) do update

--- a/supabase/migrations/0005_provision_avatar_bucket.sql
+++ b/supabase/migrations/0005_provision_avatar_bucket.sql
@@ -4,7 +4,10 @@
 -- exist" error.
 insert into storage.buckets (id, name, public)
 values ('avatars', 'avatars', false)
-on conflict (id) do nothing;
+on conflict (id) do update
+set
+  name = excluded.name,
+  public = excluded.public;
 
 drop policy if exists "Avatar files are readable by their owner" on storage.objects;
 create policy "Avatar files are readable by their owner"

--- a/supabase/migrations/0005_provision_avatar_bucket.sql
+++ b/supabase/migrations/0005_provision_avatar_bucket.sql
@@ -1,0 +1,40 @@
+-- Provision the avatars Storage bucket and policies.
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', false)
+on conflict (id) do nothing;
+
+drop policy if exists "Avatar files are readable by their owner" on storage.objects;
+create policy "Avatar files are readable by their owner"
+  on storage.objects for select
+  using (
+    bucket_id = 'avatars'
+    and auth.uid() = owner
+  );
+
+drop policy if exists "Avatar files are uploaded by their owner" on storage.objects;
+create policy "Avatar files are uploaded by their owner"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and auth.uid() = owner
+  );
+
+drop policy if exists "Avatar files are replaceable by their owner" on storage.objects;
+create policy "Avatar files are replaceable by their owner"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars'
+    and auth.uid() = owner
+  )
+  with check (
+    bucket_id = 'avatars'
+    and auth.uid() = owner
+  );
+
+drop policy if exists "Avatar files are removable by their owner" on storage.objects;
+create policy "Avatar files are removable by their owner"
+  on storage.objects for delete
+  using (
+    bucket_id = 'avatars'
+    and auth.uid() = owner
+  );

--- a/supabase/migrations/0005_provision_avatar_bucket.sql
+++ b/supabase/migrations/0005_provision_avatar_bucket.sql
@@ -1,5 +1,7 @@
 -- Provision the avatars Storage bucket and policies without relying on the
--- storage.create_bucket helper, which is missing on some Supabase instances.
+-- storage.create_bucket helper, which is missing on some Supabase instances
+-- and would otherwise raise the 42883 "function storage.create_bucket does not
+-- exist" error.
 insert into storage.buckets (id, name, public)
 values ('avatars', 'avatars', false)
 on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- clarify the Supabase setup guide to highlight the `insert ... on conflict` pattern for creating the avatars bucket when `storage.create_bucket` is unavailable
- add `0005_provision_avatar_bucket.sql` so Supabase migrations provision the avatars bucket and policies without relying on the missing helper

## Testing
- not run (Supabase CLI is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc374c6cd88322b0e045b9acfbf091