### PR TITLE
Add persistent carpenter referral links

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import {
   type ActiveCarpenter,
   type AssignedCarpenter,
   type CarpenterClient,
+  getCarpenterReferralLink,
   getAssignedCarpenter,
 } from "@/lib/carpenters";
 import { generateInvitation } from "@/lib/invitations";
@@ -95,6 +96,16 @@ export default function DashboardPage() {
   const [invitationError, setInvitationError] = useState<string | null>(null);
   const [isInvitationSubmitting, setIsInvitationSubmitting] = useState(false);
   const [inviteBaseUrl, setInviteBaseUrl] = useState<string | null>(null);
+  const [carpenterReferralToken, setCarpenterReferralToken] = useState<
+    string | null
+  >(null);
+  const [referralLinkError, setReferralLinkError] = useState<string | null>(
+    null,
+  );
+  const [hasCopiedReferralLink, setHasCopiedReferralLink] = useState(false);
+  const [referralCopyError, setReferralCopyError] = useState<string | null>(
+    null,
+  );
   const [projectCarpenterId, setProjectCarpenterId] = useState<string | null>(
     null,
   );
@@ -119,6 +130,11 @@ export default function DashboardPage() {
       setInviteBaseUrl(null);
     }
   }, []);
+
+  useEffect(() => {
+    setHasCopiedReferralLink(false);
+    setReferralCopyError(null);
+  }, [carpenterReferralToken, inviteBaseUrl]);
 
   useEffect(() => {
     if (!supabase) {
@@ -224,6 +240,8 @@ export default function DashboardPage() {
       }
 
       setDashboardError(null);
+      setReferralLinkError(null);
+      setReferralCopyError(null);
 
       try {
         const [invitationResponse, clientsList, projectList] = await Promise.all([
@@ -267,6 +285,32 @@ export default function DashboardPage() {
           error instanceof Error
             ? error.message
             : "We couldn't load your collaboration data.",
+        );
+
+        return;
+      }
+
+      if (signal?.aborted) {
+        return;
+      }
+
+      try {
+        const referralToken = await getCarpenterReferralLink(supabase);
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        setCarpenterReferralToken(referralToken);
+      } catch (error) {
+        if (signal?.aborted) {
+          return;
+        }
+
+        setReferralLinkError(
+          error instanceof Error
+            ? error.message
+            : "We couldn't load your referral link.",
         );
       }
     },
@@ -346,13 +390,39 @@ export default function DashboardPage() {
     if (accountType === "carpenter") {
       refreshCarpenterData(abortController.signal);
     } else if (accountType === "client") {
+      setCarpenterReferralToken(null);
+      setReferralLinkError(null);
+      setHasCopiedReferralLink(false);
+      setReferralCopyError(null);
       refreshClientData(abortController.signal);
+    } else {
+      setCarpenterReferralToken(null);
+      setReferralLinkError(null);
+      setHasCopiedReferralLink(false);
+      setReferralCopyError(null);
     }
 
     return () => {
       abortController.abort();
     };
   }, [accountType, refreshCarpenterData, refreshClientData, supabase, userId]);
+
+  const referralShareLink = useMemo(() => {
+    if (!carpenterReferralToken) {
+      return null;
+    }
+
+    const baseUrl =
+      inviteBaseUrl ??
+      (typeof window !== "undefined" ? window.location.origin : "");
+
+    if (!baseUrl) {
+      return `/invite/${carpenterReferralToken}`;
+    }
+
+    return `${baseUrl}/invite/${carpenterReferralToken}`;
+  }, [carpenterReferralToken, inviteBaseUrl]);
+  const isReferralLinkReady = Boolean(referralShareLink) && !referralLinkError;
 
   const handleInvitationSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -410,6 +480,36 @@ export default function DashboardPage() {
       refreshCarpenterData,
     ],
   );
+
+  const handleReferralCopy = useCallback(async () => {
+    if (!referralShareLink) {
+      return;
+    }
+
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.clipboard ||
+      typeof navigator.clipboard.writeText !== "function"
+    ) {
+      setHasCopiedReferralLink(false);
+      setReferralCopyError(
+        "Copy isn't available in this environment. Use the link below instead.",
+      );
+
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(referralShareLink);
+      setHasCopiedReferralLink(true);
+      setReferralCopyError(null);
+    } catch {
+      setHasCopiedReferralLink(false);
+      setReferralCopyError(
+        "We couldn't copy the link automatically. Try copying it manually.",
+      );
+    }
+  }, [referralShareLink]);
 
   const handleProjectSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -534,6 +634,8 @@ export default function DashboardPage() {
     return map;
   }, [assignedCarpenter, availableCarpenters]);
   const canSubmitProject = Boolean(projectCarpenterId);
+  const rawReferralDescriptionId = useId();
+  const referralLinkDescriptionId = `carpenter-referral-${rawReferralDescriptionId.replace(/:/g, "")}`;
   const rawProjectsId = useId();
   const projectsContentId = `client-projects-${rawProjectsId.replace(/:/g, "")}`;
 
@@ -924,18 +1026,51 @@ export default function DashboardPage() {
             <div className="border-t border-black/10 px-6 py-6 dark:border-white/10">
               <div className="space-y-6">
                 <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">
-                  <h2 className="text-lg font-semibold">Invite a client</h2>
+                  <h2 className="text-lg font-semibold">Invite clients</h2>
                   <p className="mt-1 text-sm/6 text-black/60 dark:text-white/60">
-                    Generate a secure link that connects new clients to your workspace.
+                    Share your reusable referral link or generate a one-off invitation for a specific email address.
                   </p>
-                  <form className="mt-4 space-y-4" onSubmit={handleInvitationSubmit} noValidate>
-                    <div className="space-y-2">
-                      <label
-                        className="text-sm font-medium text-black dark:text-white"
-                        htmlFor="invitation-email"
+                  <div className="mt-4 space-y-4">
+                    <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-emerald-900 dark:border-emerald-400/60 dark:bg-emerald-400/10 dark:text-emerald-100">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <p className="text-sm font-medium">Reusable referral link</p>
+                        <button
+                          type="button"
+                          className="inline-flex items-center justify-center rounded-md border border-emerald-300 bg-white px-3 py-1.5 text-xs font-semibold text-emerald-900 transition hover:bg-emerald-100 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-300/40 dark:bg-transparent dark:text-emerald-100 dark:hover:bg-emerald-400/20 dark:focus:ring-emerald-200/40"
+                          onClick={handleReferralCopy}
+                          disabled={!isReferralLinkReady}
+                          aria-describedby={referralLinkDescriptionId}
+                        >
+                          {hasCopiedReferralLink ? "Copied" : "Copy link"}
+                        </button>
+                      </div>
+                      <p
+                        className={`mt-2 break-all font-mono text-sm ${referralLinkError ? "text-red-700 dark:text-red-300" : ""}`}
+                        id={referralLinkDescriptionId}
                       >
-                        Client email
-                      </label>
+                        {referralLinkError
+                          ? referralLinkError
+                          : referralShareLink ?? "Generating your referral link…"}
+                      </p>
+                      {hasCopiedReferralLink ? (
+                        <p className="mt-2 text-sm font-medium text-emerald-900 dark:text-emerald-100" aria-live="polite">
+                          Link copied to clipboard.
+                        </p>
+                      ) : null}
+                      {referralCopyError ? (
+                        <p className="mt-2 text-sm text-red-700 dark:text-red-300" aria-live="polite">
+                          {referralCopyError}
+                        </p>
+                      ) : null}
+                    </div>
+                    <form className="space-y-4" onSubmit={handleInvitationSubmit} noValidate>
+                      <div className="space-y-2">
+                        <label
+                          className="text-sm font-medium text-black dark:text-white"
+                          htmlFor="invitation-email"
+                        >
+                          Client email
+                        </label>
                       <input
                         id="invitation-email"
                         type="email"
@@ -966,6 +1101,7 @@ export default function DashboardPage() {
                       {isInvitationSubmitting ? "Generating link…" : "Generate invitation"}
                     </button>
                   </form>
+                </div>
                 </article>
 
                 <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-neutral-900">

--- a/src/lib/carpenters.ts
+++ b/src/lib/carpenters.ts
@@ -16,6 +16,54 @@ export type ActiveCarpenter = {
   subscriptionExpiresAt: string | null;
 };
 
+export async function getCarpenterReferralLink(supabase: SupabaseClient) {
+  const { data, error } = await supabase.rpc("get_carpenter_referral_link");
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    throw new Error("Referral link is not available yet.");
+  }
+
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    const record = data[0];
+
+    if (!record) {
+      throw new Error("Referral link is not available yet.");
+    }
+
+    if (typeof record === "string") {
+      return record;
+    }
+
+    if (
+      record &&
+      typeof record === "object" &&
+      "referral_token" in record &&
+      typeof (record as Record<string, unknown>).referral_token === "string"
+    ) {
+      return (record as Record<string, string>).referral_token;
+    }
+  }
+
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "referral_token" in data &&
+    typeof (data as Record<string, unknown>).referral_token === "string"
+  ) {
+    return (data as Record<string, string>).referral_token;
+  }
+
+  throw new Error("Referral link is not available yet.");
+}
+
 export async function listCarpenterClients(supabase: SupabaseClient) {
   const { data, error } = await supabase.rpc("list_carpenter_clients");
 

--- a/supabase/migrations/0006_add_carpenter_referral_links.sql
+++ b/supabase/migrations/0006_add_carpenter_referral_links.sql
@@ -1,0 +1,67 @@
+-- Store a durable referral token for each carpenter and expose a helper RPC.
+
+create table if not exists public.carpenter_referrals (
+  carpenter_id uuid primary key references public.profiles(id) on delete cascade,
+  referral_token uuid not null default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create unique index if not exists carpenter_referrals_referral_token_key
+  on public.carpenter_referrals (referral_token);
+
+alter table public.carpenter_referrals enable row level security;
+
+drop policy if exists "Carpenters view their referral token" on public.carpenter_referrals;
+create policy "Carpenters view their referral token"
+  on public.carpenter_referrals
+  for select
+  using (carpenter_id = auth.uid());
+
+drop policy if exists "Carpenters create their referral token" on public.carpenter_referrals;
+create policy "Carpenters create their referral token"
+  on public.carpenter_referrals
+  for insert
+  with check (carpenter_id = auth.uid());
+
+create or replace function public.get_carpenter_referral_link()
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  current_carpenter uuid := auth.uid();
+  referral_record public.carpenter_referrals%rowtype;
+begin
+  if current_carpenter is null then
+    raise exception 'You must be signed in to request a referral link.';
+  end if;
+
+  perform 1
+  from public.profiles p
+  where p.id = current_carpenter
+    and p.account_type = 'carpenter';
+
+  if not found then
+    raise exception 'Referral links are only available to carpenters.';
+  end if;
+
+  select *
+  into referral_record
+  from public.carpenter_referrals
+  where carpenter_id = current_carpenter
+  limit 1;
+
+  if found then
+    return referral_record.referral_token::text;
+  end if;
+
+  insert into public.carpenter_referrals (carpenter_id)
+  values (current_carpenter)
+  returning * into referral_record;
+
+  return referral_record.referral_token::text;
+end;
+$$;
+
+grant execute on function public.get_carpenter_referral_link() to authenticated;


### PR DESCRIPTION
## Summary
- add a carpenter_referrals table and lazy RPC to issue durable referral tokens for carpenters
- expose a client helper that calls the referral link RPC
- update the carpenter dashboard to fetch the referral link, surface copy feedback, and clarify invitation messaging

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd163cc47483229d7c0a0cc9ac1f54