### PR TITLE
Allow reusing carpenter invitations

### DIFF
--- a/supabase/migrations/0004_projects_and_collaboration_updates.sql
+++ b/supabase/migrations/0004_projects_and_collaboration_updates.sql
@@ -250,11 +250,6 @@ begin
     raise exception 'Invitation not found';
   end if;
 
-  if invitation_record.accepted_at is not null then
-    return query
-    select invitation_record.carpenter_id, current_client;
-  end if;
-
   if invitation_record.expires_at <= timezone('utc', now()) then
     raise exception 'Invitation expired';
   end if;
@@ -263,9 +258,11 @@ begin
   values (invitation_record.carpenter_id, current_client)
   on conflict (carpenter_id, client_id) do nothing;
 
-  update public.carpenter_invitations
-  set accepted_at = timezone('utc', now())
-  where token = invitation_token;
+  if invitation_record.accepted_at is null then
+    update public.carpenter_invitations
+    set accepted_at = timezone('utc', now())
+    where token = invitation_token;
+  end if;
 
   return query
   select invitation_record.carpenter_id, current_client;

--- a/supabase/migrations/0007_update_accept_carpenter_invitation_multi_use.sql
+++ b/supabase/migrations/0007_update_accept_carpenter_invitation_multi_use.sql
@@ -1,0 +1,50 @@
+-- Ensure invitation acceptance links the signed-in client even after the token was previously used.
+create or replace function public.accept_carpenter_invitation(invitation_token uuid)
+returns table (
+  carpenter_id uuid,
+  client_id uuid
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  invitation_record public.carpenter_invitations%rowtype;
+  current_client uuid;
+begin
+  current_client := auth.uid();
+
+  if current_client is null then
+    raise exception 'You must be signed in to accept an invitation.';
+  end if;
+
+  select *
+  into invitation_record
+  from public.carpenter_invitations
+  where token = invitation_token
+  for update;
+
+  if not found then
+    raise exception 'Invitation not found';
+  end if;
+
+  if invitation_record.expires_at <= timezone('utc', now()) then
+    raise exception 'Invitation expired';
+  end if;
+
+  insert into public.carpenter_clients (carpenter_id, client_id)
+  values (invitation_record.carpenter_id, current_client)
+  on conflict (carpenter_id, client_id) do nothing;
+
+  if invitation_record.accepted_at is null then
+    update public.carpenter_invitations
+    set accepted_at = timezone('utc', now())
+    where token = invitation_token;
+  end if;
+
+  return query
+  select invitation_record.carpenter_id, current_client;
+end;
+$$;
+
+grant execute on function public.accept_carpenter_invitation(invitation_token uuid) to authenticated;


### PR DESCRIPTION
## Summary
- ensure `accept_carpenter_invitation` always links the signed-in client while preserving the first acceptance timestamp
- add a follow-up migration so the updated function is applied in existing environments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd194fb3288322a5077eee6364de76