### PR TITLE
Add bilingual homepage with language switcher

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import AppFooter from "@/components/layout/AppFooter";
 import AppHeader from "@/components/layout/AppHeader";
+import { LanguageProvider } from "@/components/providers/LanguageProvider";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -14,13 +15,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="pl">
       <body className="font-sans bg-[var(--background)] text-[var(--foreground)] antialiased">
-        <div className="flex min-h-screen flex-col">
-          <AppHeader />
-          <main className="flex flex-1 flex-col">{children}</main>
-          <AppFooter />
-        </div>
+        <LanguageProvider>
+          <div className="flex min-h-screen flex-col">
+            <AppHeader />
+            <main className="flex flex-1 flex-col">{children}</main>
+            <AppFooter />
+          </div>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,29 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 
+import { useLanguage } from "@/components/providers/LanguageProvider";
+import { translations } from "@/lib/i18n";
+
 export default function Home() {
+  const { language } = useLanguage();
+  const { hero, sections } = translations[language];
+
   return (
     <main className="min-h-screen bg-gradient-to-br from-neutral-50 via-white to-neutral-100 dark:from-neutral-950 dark:via-neutral-900 dark:to-neutral-950">
       <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-24 px-4 py-16">
         <section className="grid items-center gap-12 md:grid-cols-[1.1fr,0.9fr]">
           <div className="space-y-8 text-center md:text-left">
             <span className="inline-flex items-center justify-center rounded-full border border-black/10 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-black/70 dark:border-white/20 dark:text-white/70">
-              kreator zabudowy stolarskiej
+              {hero.badge}
             </span>
             <div className="space-y-5">
               <h1 className="text-5xl font-semibold tracking-tight text-black sm:text-6xl dark:text-white">
-                Zaprojektuj wymarzoną zabudowę bez wychodzenia z domu
+                {hero.heading}
               </h1>
               <p className="text-lg text-black/60 dark:text-white/60 sm:text-xl">
-                Meblomat łączy wizualny konfigurator z wiedzą stolarzy. W kilka minut zbudujesz projekt, dobierzesz materiały
-                i przygotujesz kompletny zestaw formatki do produkcji.
+                {hero.description}
               </p>
             </div>
             <div className="flex flex-wrap justify-center gap-3 md:justify-start">
@@ -24,20 +31,20 @@ export default function Home() {
                 className="inline-flex items-center justify-center rounded-full bg-black px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-black/80 dark:bg-white dark:text-black dark:hover:bg-white/80"
                 href="/auth/register"
               >
-                Rozpocznij darmową próbę
+                {hero.primaryCta}
               </Link>
               <Link
                 className="inline-flex items-center justify-center rounded-full border border-black/10 px-6 py-3 text-sm font-semibold text-black transition hover:border-black/20 hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:border-white/40 dark:hover:bg-white/10"
                 href="/play"
               >
-                Zobacz przykład konfiguracji
+                {hero.secondaryCta}
               </Link>
             </div>
           </div>
           <div className="relative flex items-center justify-center">
             <div className="absolute inset-6 rounded-3xl bg-black/5 blur-3xl dark:bg-white/5" aria-hidden="true" />
             <Image
-              alt="Wizualizacja projektu mebli na wymiar"
+              alt={hero.imageAlt}
               className="relative mx-auto w-full max-w-md rounded-3xl border border-black/10 bg-white/60 p-6 shadow-xl dark:border-white/10 dark:bg-neutral-900/60"
               height={480}
               src="/window.svg"
@@ -51,20 +58,17 @@ export default function Home() {
           id="meble"
         >
           <div className="space-y-4">
-            <h2 className="text-3xl font-semibold text-black dark:text-white">Projektuj meble dokładnie tak, jak potrzebujesz</h2>
-            <p className="text-base text-black/70 dark:text-white/70">
-              Elastyczny konfigurator pozwala budować szafy, zabudowy kuchenne i meble biurowe z zachowaniem dokładnych wymiarów.
-              Wybierasz fronty, korpusy oraz akcesoria z biblioteki dostawców i natychmiast widzisz efekt na ekranie.
-            </p>
+            <h2 className="text-3xl font-semibold text-black dark:text-white">{sections.meble.title}</h2>
+            <p className="text-base text-black/70 dark:text-white/70">{sections.meble.description}</p>
             <ul className="space-y-2 text-sm text-black/70 dark:text-white/70">
-              <li>• Gotowe szablony zabudów narożnych i wnękowych</li>
-              <li>• Szczegółowe sterowanie podziałami, frontami i okuciami</li>
-              <li>• Eksport projektu do PDF z rysunkami technicznymi</li>
+              {sections.meble.bullets.map((bullet) => (
+                <li key={bullet}>• {bullet}</li>
+              ))}
             </ul>
           </div>
           <div className="flex items-center justify-center">
             <Image
-              alt="Panel konfiguracji mebli"
+              alt={sections.meble.imageAlt}
               className="w-full max-w-xs rounded-2xl border border-black/10 bg-white/70 p-5 shadow-md dark:border-white/10 dark:bg-neutral-800/70"
               height={360}
               src="/globe.svg"
@@ -79,7 +83,7 @@ export default function Home() {
         >
           <div className="flex items-center justify-center">
             <Image
-              alt="Skanowanie pomieszczenia"
+              alt={sections.pomieszczenie.imageAlt}
               className="w-full max-w-xs rounded-2xl border border-black/10 bg-white/70 p-5 shadow-md dark:border-white/10 dark:bg-neutral-800/70"
               height={360}
               src="/file.svg"
@@ -87,15 +91,12 @@ export default function Home() {
             />
           </div>
           <div className="space-y-4">
-            <h2 className="text-3xl font-semibold text-black dark:text-white">Dopasuj zabudowę do realnych wymiarów pomieszczenia</h2>
-            <p className="text-base text-black/70 dark:text-white/70">
-              Wprowadź wymiary pomieszczenia lub wykorzystaj pliki z pomiarów laserowych. Kreator podpowie optymalny układ elementów,
-              aby maksymalnie wykorzystać dostępną przestrzeń i zachować ergonomię.
-            </p>
+            <h2 className="text-3xl font-semibold text-black dark:text-white">{sections.pomieszczenie.title}</h2>
+            <p className="text-base text-black/70 dark:text-white/70">{sections.pomieszczenie.description}</p>
             <ul className="space-y-2 text-sm text-black/70 dark:text-white/70">
-              <li>• Szybkie dopasowanie skosów, wnęk i nietypowych wysokości</li>
-              <li>• Weryfikacja kolizji z instalacjami oraz sprzętem AGD</li>
-              <li>• Widok 3D z możliwością udostępnienia klientowi</li>
+              {sections.pomieszczenie.bullets.map((bullet) => (
+                <li key={bullet}>• {bullet}</li>
+              ))}
             </ul>
           </div>
         </section>
@@ -105,20 +106,17 @@ export default function Home() {
           id="wycena"
         >
           <div className="space-y-4">
-            <h2 className="text-3xl font-semibold text-black dark:text-white">Przygotuj ofertę i kosztorys jednym kliknięciem</h2>
-            <p className="text-base text-black/70 dark:text-white/70">
-              System automatycznie wylicza zużycie materiałów, okucia oraz robociznę na podstawie Twoich cenników. Wygenerujesz
-              czytelną ofertę PDF wraz z wizualizacjami i listą elementów do zamówienia.
-            </p>
+            <h2 className="text-3xl font-semibold text-black dark:text-white">{sections.wycena.title}</h2>
+            <p className="text-base text-black/70 dark:text-white/70">{sections.wycena.description}</p>
             <ul className="space-y-2 text-sm text-black/70 dark:text-white/70">
-              <li>• Aktualizacja stawek i rabatów w czasie rzeczywistym</li>
-              <li>• Historia ofert i statusów akceptacji klienta</li>
-              <li>• Integracja z systemami księgowymi i magazynowymi</li>
+              {sections.wycena.bullets.map((bullet) => (
+                <li key={bullet}>• {bullet}</li>
+              ))}
             </ul>
           </div>
           <div className="flex items-center justify-center">
             <Image
-              alt="Panel wyceny"
+              alt={sections.wycena.imageAlt}
               className="w-full max-w-xs rounded-2xl border border-black/10 bg-white/70 p-5 shadow-md dark:border-white/10 dark:bg-neutral-800/70"
               height={360}
               src="/next.svg"
@@ -133,7 +131,7 @@ export default function Home() {
         >
           <div className="flex items-center justify-center">
             <Image
-              alt="Lista formatek do produkcji"
+              alt={sections.formatki.imageAlt}
               className="w-full max-w-xs rounded-2xl border border-black/10 bg-white/70 p-5 shadow-md dark:border-white/10 dark:bg-neutral-800/70"
               height={360}
               src="/vercel.svg"
@@ -141,15 +139,12 @@ export default function Home() {
             />
           </div>
           <div className="space-y-4">
-            <h2 className="text-3xl font-semibold text-black dark:text-white">Eksportuj formatki gotowe dla stolarni</h2>
-            <p className="text-base text-black/70 dark:text-white/70">
-              Generuj listy formatek z rozkrojem płyt, opisem oklein oraz oznaczeniami otworów montażowych. Pliki wyślesz bezpośrednio
-              do swojego dostawcy lub przekażesz do programu optymalizującego cięcie.
-            </p>
+            <h2 className="text-3xl font-semibold text-black dark:text-white">{sections.formatki.title}</h2>
+            <p className="text-base text-black/70 dark:text-white/70">{sections.formatki.description}</p>
             <ul className="space-y-2 text-sm text-black/70 dark:text-white/70">
-              <li>• Eksport w formatach CSV, DXF oraz kompatybilnych z CNC</li>
-              <li>• Automatyczne generowanie etykiet elementów</li>
-              <li>• Harmonogram produkcji zsynchronizowany z kalendarzem</li>
+              {sections.formatki.bullets.map((bullet) => (
+                <li key={bullet}>• {bullet}</li>
+              ))}
             </ul>
           </div>
         </section>

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -3,10 +3,15 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
+import { useLanguage } from "@/components/providers/LanguageProvider";
+import { translations } from "@/lib/i18n";
+
 const FALLBACK_YEAR = "";
 
 export default function AppFooter() {
   const [year, setYear] = useState<string>(FALLBACK_YEAR);
+  const { language } = useLanguage();
+  const { footer, header } = translations[language];
 
   useEffect(() => {
     setYear(String(new Date().getFullYear()));
@@ -16,10 +21,11 @@ export default function AppFooter() {
     <footer className="border-t border-black/10 bg-white/80 px-4 py-6 text-sm text-black/60 dark:border-white/10 dark:bg-neutral-900/80 dark:text-white/60">
       <div className="mx-auto flex w-full max-w-5xl items-center justify-between">
         <span>
-          &copy; {year ? `${year} ` : ""}Meblomat. All rights reserved.
+          &copy; {year ? `${year} ` : ""}
+          {header.brand}. {footer.rights}
         </span>
         <Link className="font-medium text-black transition hover:text-black/80 dark:text-white dark:hover:text-white/80" href="/auth/register">
-          Get started
+          {footer.cta}
         </Link>
       </div>
     </footer>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -4,24 +4,29 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import type { User } from "@supabase/supabase-js";
 
+import { useLanguage } from "@/components/providers/LanguageProvider";
+import LanguageSwitcher from "@/components/layout/LanguageSwitcher";
+import { getAccountTypeIcon, type AccountType } from "@/lib/avatar";
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
-import { getAccountTypeIcon, type AccountType } from "@/lib/avatar";
+import { translations } from "@/lib/i18n";
 
 import { UserAvatar } from "./UserAvatar";
 
+type NavigationKey = "meble" | "pomieszczenie" | "wycena" | "formatki" | "play";
+
 type NavigationLink = {
   href: string;
-  label: string;
+  key: NavigationKey;
   withIcon?: boolean;
 };
 
 const navigationLinks: NavigationLink[] = [
-  { href: "/#meble", label: "meble" },
-  { href: "/#pomieszczenie", label: "pomieszczenie" },
-  { href: "/#wycena", label: "wycena" },
-  { href: "/#formatki", label: "formatki" },
-  { href: "/play", label: "play", withIcon: true },
+  { href: "/#meble", key: "meble" },
+  { href: "/#pomieszczenie", key: "pomieszczenie" },
+  { href: "/#wycena", key: "wycena" },
+  { href: "/#formatki", key: "formatki" },
+  { href: "/play", key: "play", withIcon: true },
 ];
 
 type ProfileRow = {
@@ -29,6 +34,7 @@ type ProfileRow = {
 };
 
 export default function AppHeader() {
+  const { language } = useLanguage();
   const isSupabaseConfigured = isSupabaseConfiguredOnClient();
   const supabase = useMemo(
     () => (isSupabaseConfigured ? createSupabaseBrowserClient() : null),
@@ -129,6 +135,7 @@ export default function AppHeader() {
     </span>
   );
   const avatarInitial = user?.email?.[0]?.toUpperCase() ?? undefined;
+  const { header, navigation } = translations[language];
 
   return (
     <header className="border-b border-black/10 bg-white/80 px-4 py-4 backdrop-blur-sm dark:border-white/10 dark:bg-neutral-900/80">
@@ -138,17 +145,17 @@ export default function AppHeader() {
             className="text-lg font-semibold tracking-tight text-black transition hover:text-black/70 dark:text-white dark:hover:text-white/80"
             href="/"
           >
-            Meblomat
+            {header.brand}
           </Link>
           <nav className="flex items-center gap-3 text-sm font-medium text-black/70 dark:text-white/70">
             {navigationLinks.map((item) => (
               <Link
-                key={item.label}
+                key={item.key}
                 className="rounded-full px-3 py-1 capitalize transition hover:bg-black/5 hover:text-black dark:hover:bg-white/10 dark:hover:text-white"
                 href={item.href}
               >
                 <span className="flex items-center gap-1">
-                  {item.label}
+                  {navigation[item.key]}
                   {item.withIcon ? (
                     <span aria-hidden="true" className="text-xs">
                       ▶
@@ -159,7 +166,8 @@ export default function AppHeader() {
             ))}
           </nav>
         </div>
-        <div className="flex flex-col items-end gap-3 text-sm font-medium">
+        <div className="flex items-center gap-3 text-sm font-medium">
+          <LanguageSwitcher />
           {isAuthenticated ? (
             <Link href="/dashboard" className="rounded-full">
               <UserAvatar
@@ -173,13 +181,13 @@ export default function AppHeader() {
                 className="rounded-full px-4 py-2 text-black transition hover:bg-black/5 dark:text-white dark:hover:bg-white/10"
                 href="/auth/login"
               >
-                Zaloguj się
+                {header.login}
               </Link>
               <Link
                 className="rounded-full bg-black px-4 py-2 text-white shadow-sm transition hover:bg-black/80 dark:bg-white dark:text-black dark:hover:bg-white/80"
                 href="/auth/register"
               >
-                Utwórz konto
+                {header.register}
               </Link>
             </div>
           )}

--- a/src/components/layout/LanguageSwitcher.tsx
+++ b/src/components/layout/LanguageSwitcher.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useLanguage } from "@/components/providers/LanguageProvider";
+import { supportedLanguages, translations, type Language } from "@/lib/i18n";
+
+export default function LanguageSwitcher() {
+  const { language, setLanguage } = useLanguage();
+  const { header } = useMemo(() => translations[language], [language]);
+
+  const handleChange = (next: Language) => {
+    if (next === language) {
+      return;
+    }
+
+    setLanguage(next);
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-black/10 bg-white/70 px-2 py-1 text-xs font-medium text-black/70 shadow-sm dark:border-white/10 dark:bg-neutral-900/70 dark:text-white/70">
+      <span aria-hidden="true" className="text-base">
+        🌐
+      </span>
+      <span className="sr-only">{header.languageLabel}</span>
+      <div className="flex items-center gap-1">
+        {supportedLanguages.map((key) => {
+          const isActive = key === language;
+          return (
+            <button
+              key={key}
+              aria-pressed={isActive}
+              className={`rounded-full px-2 py-1 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-black/40 dark:focus-visible:ring-white/40 ${
+                isActive
+                  ? "bg-black text-white dark:bg-white dark:text-black"
+                  : "text-black/70 hover:bg-black/10 dark:text-white/70 dark:hover:bg-white/10"
+              }`}
+              onClick={() => handleChange(key)}
+              title={header.languageNames[key]}
+              type="button"
+            >
+              {header.languageShort[key]}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/providers/LanguageProvider.tsx
+++ b/src/components/providers/LanguageProvider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+import type { Language } from "@/lib/i18n";
+import { supportedLanguages } from "@/lib/i18n";
+
+type LanguageContextValue = {
+  language: Language;
+  setLanguage: (next: Language) => void;
+};
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+const STORAGE_KEY = "meblomat-language";
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguage] = useState<Language>("pl");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && supportedLanguages.includes(stored as Language)) {
+      setLanguage(stored as Language);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, language);
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+    }),
+    [language],
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+
+  return context;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,213 @@
+export type Language = "pl" | "en";
+
+type SectionContent = {
+  title: string;
+  description: string;
+  bullets: string[];
+  imageAlt: string;
+};
+
+type Translations = {
+  navigation: {
+    meble: string;
+    pomieszczenie: string;
+    wycena: string;
+    formatki: string;
+    play: string;
+  };
+  header: {
+    login: string;
+    register: string;
+    languageLabel: string;
+    languageNames: Record<Language, string>;
+    languageShort: Record<Language, string>;
+    brand: string;
+  };
+  hero: {
+    badge: string;
+    heading: string;
+    description: string;
+    primaryCta: string;
+    secondaryCta: string;
+    imageAlt: string;
+  };
+  sections: {
+    meble: SectionContent;
+    pomieszczenie: SectionContent;
+    wycena: SectionContent;
+    formatki: SectionContent;
+  };
+  footer: {
+    rights: string;
+    cta: string;
+  };
+};
+
+export const translations: Record<Language, Translations> = {
+  pl: {
+    navigation: {
+      meble: "meble",
+      pomieszczenie: "pomieszczenie",
+      wycena: "wycena",
+      formatki: "formatki",
+      play: "zobacz demo",
+    },
+    header: {
+      login: "Zaloguj się",
+      register: "Utwórz konto",
+      languageLabel: "Zmień język",
+      languageNames: {
+        pl: "Polski",
+        en: "Angielski",
+      },
+      languageShort: {
+        pl: "PL",
+        en: "EN",
+      },
+      brand: "Meblomat",
+    },
+    hero: {
+      badge: "kreator zabudowy stolarskiej",
+      heading: "Zaprojektuj wymarzoną zabudowę bez wychodzenia z domu",
+      description:
+        "Meblomat łączy wizualny konfigurator z wiedzą stolarzy. W kilka minut zbudujesz projekt, dobierzesz materiały i przygotujesz kompletny zestaw formatek do produkcji.",
+      primaryCta: "Rozpocznij darmową próbę",
+      secondaryCta: "Zobacz przykład konfiguracji",
+      imageAlt: "Wizualizacja projektu mebli na wymiar",
+    },
+    sections: {
+      meble: {
+        title: "Projektuj meble dokładnie tak, jak potrzebujesz",
+        description:
+          "Elastyczny konfigurator pozwala budować szafy, zabudowy kuchenne i meble biurowe z zachowaniem dokładnych wymiarów. Wybierasz fronty, korpusy oraz akcesoria z biblioteki dostawców i natychmiast widzisz efekt na ekranie.",
+        bullets: [
+          "Gotowe szablony zabudów narożnych i wnękowych",
+          "Szczegółowe sterowanie podziałami, frontami i okuciami",
+          "Eksport projektu do PDF z rysunkami technicznymi",
+        ],
+        imageAlt: "Panel konfiguracji mebli",
+      },
+      pomieszczenie: {
+        title: "Dopasuj zabudowę do realnych wymiarów pomieszczenia",
+        description:
+          "Wprowadź wymiary pomieszczenia lub wykorzystaj pliki z pomiarów laserowych. Kreator podpowie optymalny układ elementów, aby maksymalnie wykorzystać dostępną przestrzeń i zachować ergonomię.",
+        bullets: [
+          "Szybkie dopasowanie skosów, wnęk i nietypowych wysokości",
+          "Weryfikacja kolizji z instalacjami oraz sprzętem AGD",
+          "Widok 3D z możliwością udostępnienia klientowi",
+        ],
+        imageAlt: "Skanowanie pomieszczenia",
+      },
+      wycena: {
+        title: "Przygotuj ofertę i kosztorys jednym kliknięciem",
+        description:
+          "System automatycznie wylicza zużycie materiałów, okucia oraz robociznę na podstawie Twoich cenników. Wygenerujesz czytelną ofertę PDF wraz z wizualizacjami i listą elementów do zamówienia.",
+        bullets: [
+          "Aktualizacja stawek i rabatów w czasie rzeczywistym",
+          "Historia ofert i statusów akceptacji klienta",
+          "Integracja z systemami księgowymi i magazynowymi",
+        ],
+        imageAlt: "Panel wyceny",
+      },
+      formatki: {
+        title: "Eksportuj formatki gotowe dla stolarni",
+        description:
+          "Generuj listy formatek z rozkrojem płyt, opisem oklein oraz oznaczeniami otworów montażowych. Pliki wyślesz bezpośrednio do swojego dostawcy lub przekażesz do programu optymalizującego cięcie.",
+        bullets: [
+          "Eksport w formatach CSV, DXF oraz kompatybilnych z CNC",
+          "Automatyczne generowanie etykiet elementów",
+          "Harmonogram produkcji zsynchronizowany z kalendarzem",
+        ],
+        imageAlt: "Lista formatek do produkcji",
+      },
+    },
+    footer: {
+      rights: "Wszelkie prawa zastrzeżone.",
+      cta: "Załóż konto",
+    },
+  },
+  en: {
+    navigation: {
+      meble: "furniture",
+      pomieszczenie: "workspace",
+      wycena: "pricing",
+      formatki: "cut lists",
+      play: "view demo",
+    },
+    header: {
+      login: "Log in",
+      register: "Create account",
+      languageLabel: "Change language",
+      languageNames: {
+        pl: "Polish",
+        en: "English",
+      },
+      languageShort: {
+        pl: "PL",
+        en: "EN",
+      },
+      brand: "Meblomat",
+    },
+    hero: {
+      badge: "cabinetry design suite",
+      heading: "Design custom-built furniture without leaving home",
+      description:
+        "Meblomat combines a visual configurator with expert joinery knowledge. Build projects, choose materials, and prepare complete cutting lists for production in minutes.",
+      primaryCta: "Start free trial",
+      secondaryCta: "See configuration example",
+      imageAlt: "Visualization of custom furniture project",
+    },
+    sections: {
+      meble: {
+        title: "Design furniture exactly the way you need",
+        description:
+          "A flexible configurator lets you create wardrobes, kitchen fittings, and office furniture with precise dimensions. Choose fronts, carcasses, and fittings from supplier libraries and instantly see the result on screen.",
+        bullets: [
+          "Ready-made templates for corner and alcove layouts",
+          "Detailed control over divisions, fronts, and hardware",
+          "Export projects to PDF with technical drawings",
+        ],
+        imageAlt: "Furniture configuration panel",
+      },
+      pomieszczenie: {
+        title: "Match cabinetry to real room measurements",
+        description:
+          "Enter room dimensions or import laser measurement files. The wizard suggests the optimal arrangement to maximize space while maintaining ergonomics.",
+        bullets: [
+          "Quick adjustments for slants, niches, and unusual heights",
+          "Collision checks with utilities and appliances",
+          "Shareable 3D view for your client",
+        ],
+        imageAlt: "Room scanning",
+      },
+      wycena: {
+        title: "Prepare offers and cost estimates in one click",
+        description:
+          "The system automatically calculates materials, hardware, and labor using your price lists. Generate a clear PDF offer with visualizations and a ready-to-order item list.",
+        bullets: [
+          "Real-time updates for rates and discounts",
+          "Offer history with client approval statuses",
+          "Integration with accounting and inventory systems",
+        ],
+        imageAlt: "Pricing panel",
+      },
+      formatki: {
+        title: "Export cutting lists ready for the workshop",
+        description:
+          "Generate board cutting lists with edging details and drilling marks. Send files directly to suppliers or pass them to cutting optimization software.",
+        bullets: [
+          "Export to CSV, DXF, and CNC-ready formats",
+          "Automatic generation of part labels",
+          "Production schedule synchronized with your calendar",
+        ],
+        imageAlt: "Cut lists prepared for production",
+      },
+    },
+    footer: {
+      rights: "All rights reserved.",
+      cta: "Get started",
+    },
+  },
+};
+
+export const supportedLanguages: Language[] = ["pl", "en"];


### PR DESCRIPTION
## Summary
- add a reusable language provider and translation dictionary for Polish and English content
- update the header, footer, and landing page to consume translations and expose a globe language switcher next to auth actions
- ensure layout wraps the app with the new provider so text updates instantly when the language changes

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1db8c5fc8322ba5091836afc44a1