### PR TITLE
Add auth translations for Polish locale

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -6,11 +6,15 @@ import { useRouter } from "next/navigation";
 
 import { SupabaseEnvWarning } from "@/components/SupabaseEnvWarning";
 import { AuthForm } from "@/components/auth/AuthForm";
+import { useLanguage } from "@/components/providers/LanguageProvider";
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
+import { translations } from "@/lib/i18n";
 
 export default function LoginPage() {
   const router = useRouter();
+  const { language } = useLanguage();
+  const { login: loginTexts } = translations[language].auth;
   const isSupabaseConfigured = isSupabaseConfiguredOnClient();
   const supabase = useMemo(
     () => (isSupabaseConfigured ? createSupabaseBrowserClient() : null),
@@ -56,16 +60,14 @@ export default function LoginPage() {
   return (
     <div className="space-y-6">
       <div className="space-y-2 text-center sm:text-left">
-        <h1 className="text-3xl font-semibold tracking-tight">Welcome back</h1>
-        <p className="text-sm/6 text-black/60 dark:text-white/60">
-          Sign in to continue where you left off.
-        </p>
+        <h1 className="text-3xl font-semibold tracking-tight">{loginTexts.title}</h1>
+        <p className="text-sm/6 text-black/60 dark:text-white/60">{loginTexts.description}</p>
       </div>
       <AuthForm view="sign_in" className="space-y-4" />
       <p className="text-sm/6 text-black/60 dark:text-white/60">
-        Don&apos;t have an account?{" "}
+        {loginTexts.noAccountPrompt}{" "}
         <Link className="font-semibold text-black dark:text-white" href="/auth/register">
-          Create one
+          {loginTexts.registerLinkLabel}
         </Link>
         .
       </p>

--- a/src/app/auth/register/SignUpForm.tsx
+++ b/src/app/auth/register/SignUpForm.tsx
@@ -4,6 +4,9 @@ import { FormEvent, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+import { useLanguage } from "@/components/providers/LanguageProvider";
+import { translations } from "@/lib/i18n";
+
 const EMAIL_REDIRECT_PATH = "/auth/verify";
 
 type AccountType = "carpenter" | "client";
@@ -31,6 +34,8 @@ function resolveForcedAccountType(
 export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { language } = useLanguage();
+  const formTexts = translations[language].auth.signUpForm;
   const invitationToken = searchParams?.get("invitation") ?? undefined;
   const accountParam = searchParams?.get("account") ?? null;
   const forcedAccountType = resolveForcedAccountType(invitationToken, accountParam);
@@ -72,12 +77,12 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
     setStatusMessage(null);
 
     if (!email.trim()) {
-      setFormError("Email is required.");
+      setFormError(formTexts.errors.emailRequired);
       return;
     }
 
     if (!password) {
-      setFormError("Password is required.");
+      setFormError(formTexts.errors.passwordRequired);
       return;
     }
 
@@ -108,7 +113,7 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
 
       if (session) {
         if (!user) {
-          setFormError("Registration failed.");
+          setFormError(formTexts.errors.registrationFailed);
           return;
         }
 
@@ -140,11 +145,10 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
         return;
       }
 
-      setStatusMessage(
-        "Check your email for a confirmation link to finish setting up your account.",
-      );
+      setStatusMessage(formTexts.status.checkEmail);
     } catch (unknownError) {
-      setFormError(unknownError instanceof Error ? unknownError.message : "Registration failed.");
+      const fallbackError = formTexts.errors.registrationFailed;
+      setFormError(unknownError instanceof Error ? unknownError.message : fallbackError);
     } finally {
       setIsSubmitting(false);
     }
@@ -154,7 +158,7 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
     <form className="space-y-4" onSubmit={handleSubmit} noValidate>
       <div className="space-y-2">
         <label className="text-sm font-medium text-black dark:text-white" htmlFor="email">
-          Email
+          {formTexts.emailLabel}
         </label>
         <input
           id="email"
@@ -169,7 +173,7 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
 
       <div className="space-y-2">
         <label className="text-sm font-medium text-black dark:text-white" htmlFor="password">
-          Password
+          {formTexts.passwordLabel}
         </label>
         <input
           id="password"
@@ -183,7 +187,9 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
       </div>
 
       <fieldset className="space-y-2">
-        <legend className="text-sm font-medium text-black dark:text-white">Account type</legend>
+        <legend className="text-sm font-medium text-black dark:text-white">
+          {formTexts.accountTypeLegend}
+        </legend>
         <div className="space-y-2">
           <label className="flex cursor-pointer items-center gap-3 rounded-md border border-black/10 bg-white p-3 transition hover:border-black/30 dark:border-white/20 dark:bg-black dark:hover:border-white/40">
             <input
@@ -195,9 +201,11 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
               disabled={Boolean(forcedAccountType)}
             />
             <div>
-              <p className="text-sm font-medium text-black dark:text-white">stolarz (subscription)</p>
+              <p className="text-sm font-medium text-black dark:text-white">
+                {formTexts.accountTypes.carpenter.label}
+              </p>
               <p className="text-sm text-black/60 dark:text-white/60">
-                Unlock all professional features with a paid carpenter plan.
+                {formTexts.accountTypes.carpenter.description}
               </p>
             </div>
           </label>
@@ -211,16 +219,18 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
               disabled={Boolean(forcedAccountType)}
             />
             <div>
-              <p className="text-sm font-medium text-black dark:text-white">klient (free)</p>
+              <p className="text-sm font-medium text-black dark:text-white">
+                {formTexts.accountTypes.client.label}
+              </p>
               <p className="text-sm text-black/60 dark:text-white/60">
-                Collaborate with your carpenter at no additional cost.
+                {formTexts.accountTypes.client.description}
               </p>
             </div>
           </label>
         </div>
         {forcedAccountType ? (
           <p className="text-xs text-black/60 dark:text-white/60">
-            Your account type is locked because you are joining from an invitation.
+            {formTexts.accountTypeLocked}
           </p>
         ) : null}
       </fieldset>
@@ -242,7 +252,7 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
         className="inline-flex w-full items-center justify-center rounded-md bg-black px-4 py-2 text-sm font-semibold text-white transition hover:bg-black/90 focus:outline-none focus:ring-2 focus:ring-black/20 disabled:cursor-not-allowed disabled:bg-black/40 dark:bg-white dark:text-black dark:hover:bg-white/90 dark:focus:ring-white/30 dark:disabled:bg-white/40"
         disabled={isSubmitting}
       >
-        {isSubmitting ? "Creating account…" : "Create account"}
+        {isSubmitting ? formTexts.submit.submitting : formTexts.submit.default}
       </button>
     </form>
   );

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -5,13 +5,17 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { SupabaseEnvWarning } from "@/components/SupabaseEnvWarning";
+import { useLanguage } from "@/components/providers/LanguageProvider";
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
+import { translations } from "@/lib/i18n";
 
 import { SignUpForm } from "./SignUpForm";
 
 export default function RegisterPage() {
   const router = useRouter();
+  const { language } = useLanguage();
+  const { register: registerTexts } = translations[language].auth;
   const isSupabaseConfigured = isSupabaseConfiguredOnClient();
   const supabase = useMemo(
     () => (isSupabaseConfigured ? createSupabaseBrowserClient() : null),
@@ -61,10 +65,8 @@ export default function RegisterPage() {
   return (
     <div className="space-y-6">
       <div className="space-y-2 text-center sm:text-left">
-        <h1 className="text-3xl font-semibold tracking-tight">Create your account</h1>
-        <p className="text-sm/6 text-black/60 dark:text-white/60">
-          Register with your email address and we&apos;ll send a confirmation link.
-        </p>
+        <h1 className="text-3xl font-semibold tracking-tight">{registerTexts.title}</h1>
+        <p className="text-sm/6 text-black/60 dark:text-white/60">{registerTexts.description}</p>
       </div>
       <Suspense
         fallback={
@@ -88,9 +90,9 @@ export default function RegisterPage() {
         <SignUpForm supabase={supabase} />
       </Suspense>
       <p className="text-sm/6 text-black/60 dark:text-white/60">
-        Already have an account?{" "}
+        {registerTexts.hasAccountPrompt}{" "}
         <Link className="font-semibold text-black dark:text-white" href="/auth/login">
-          Sign in
+          {registerTexts.loginLinkLabel}
         </Link>
         .
       </p>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -23,6 +23,48 @@ type Translations = {
     languageShort: Record<Language, string>;
     brand: string;
   };
+  auth: {
+    login: {
+      title: string;
+      description: string;
+      noAccountPrompt: string;
+      registerLinkLabel: string;
+    };
+    register: {
+      title: string;
+      description: string;
+      hasAccountPrompt: string;
+      loginLinkLabel: string;
+    };
+    signUpForm: {
+      emailLabel: string;
+      passwordLabel: string;
+      accountTypeLegend: string;
+      accountTypes: {
+        carpenter: {
+          label: string;
+          description: string;
+        };
+        client: {
+          label: string;
+          description: string;
+        };
+      };
+      accountTypeLocked: string;
+      errors: {
+        emailRequired: string;
+        passwordRequired: string;
+        registrationFailed: string;
+      };
+      status: {
+        checkEmail: string;
+      };
+      submit: {
+        default: string;
+        submitting: string;
+      };
+    };
+  };
   hero: {
     badge: string;
     heading: string;
@@ -65,6 +107,52 @@ export const translations: Record<Language, Translations> = {
         en: "EN",
       },
       brand: "Meblomat",
+    },
+    auth: {
+      login: {
+        title: "Witamy ponownie",
+        description: "Zaloguj się, aby kontynuować pracę.",
+        noAccountPrompt: "Nie masz jeszcze konta?",
+        registerLinkLabel: "Utwórz je",
+      },
+      register: {
+        title: "Utwórz konto",
+        description:
+          "Zarejestruj się przy użyciu adresu e-mail – wyślemy link potwierdzający.",
+        hasAccountPrompt: "Masz już konto?",
+        loginLinkLabel: "Zaloguj się",
+      },
+      signUpForm: {
+        emailLabel: "Adres e-mail",
+        passwordLabel: "Hasło",
+        accountTypeLegend: "Typ konta",
+        accountTypes: {
+          carpenter: {
+            label: "Stolarz (abonament)",
+            description:
+              "Odblokuj wszystkie funkcje profesjonalne w płatnym planie dla stolarzy.",
+          },
+          client: {
+            label: "Klient (bezpłatnie)",
+            description: "Współpracuj ze swoim stolarzem bez dodatkowych kosztów.",
+          },
+        },
+        accountTypeLocked:
+          "Nie możesz zmienić typu konta, ponieważ dołączasz z zaproszenia.",
+        errors: {
+          emailRequired: "Adres e-mail jest wymagany.",
+          passwordRequired: "Hasło jest wymagane.",
+          registrationFailed: "Rejestracja nie powiodła się.",
+        },
+        status: {
+          checkEmail:
+            "Sprawdź skrzynkę e-mail i kliknij link potwierdzający, aby dokończyć zakładanie konta.",
+        },
+        submit: {
+          default: "Utwórz konto",
+          submitting: "Tworzenie konta…",
+        },
+      },
     },
     hero: {
       badge: "kreator zabudowy stolarskiej",
@@ -147,6 +235,52 @@ export const translations: Record<Language, Translations> = {
         en: "EN",
       },
       brand: "Meblomat",
+    },
+    auth: {
+      login: {
+        title: "Welcome back",
+        description: "Sign in to continue where you left off.",
+        noAccountPrompt: "Don't have an account?",
+        registerLinkLabel: "Create one",
+      },
+      register: {
+        title: "Create your account",
+        description:
+          "Register with your email address and we'll send a confirmation link.",
+        hasAccountPrompt: "Already have an account?",
+        loginLinkLabel: "Sign in",
+      },
+      signUpForm: {
+        emailLabel: "Email",
+        passwordLabel: "Password",
+        accountTypeLegend: "Account type",
+        accountTypes: {
+          carpenter: {
+            label: "Carpenter (subscription)",
+            description:
+              "Unlock all professional features with a paid carpenter plan.",
+          },
+          client: {
+            label: "Client (free)",
+            description: "Collaborate with your carpenter at no additional cost.",
+          },
+        },
+        accountTypeLocked:
+          "Your account type is locked because you are joining from an invitation.",
+        errors: {
+          emailRequired: "Email is required.",
+          passwordRequired: "Password is required.",
+          registrationFailed: "Registration failed.",
+        },
+        status: {
+          checkEmail:
+            "Check your email for a confirmation link to finish setting up your account.",
+        },
+        submit: {
+          default: "Create account",
+          submitting: "Creating account…",
+        },
+      },
     },
     hero: {
       badge: "cabinetry design suite",


### PR DESCRIPTION
## Summary
- extend the translation catalog with authentication strings for login and registration flows
- localize the login and registration pages using the active language
- translate the custom sign-up form labels, validation errors and button text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd25946f948322b599fc3f4551e1c0