### PR TITLE
Adjust authenticated navigation and add protected feature pages

### DIFF
--- a/src/app/formatki/page.tsx
+++ b/src/app/formatki/page.tsx
@@ -1,0 +1,16 @@
+import type { AccountType } from "@/lib/avatar";
+import { ProtectedFeaturePage, UnauthorizedNotice } from "@/components/protected/ProtectedFeaturePage";
+import { requireAuthenticatedUser } from "@/lib/serverAuth";
+
+const allowedAccountTypes: AccountType[] = ["admin", "carpenter"];
+
+export default async function FormatkiPage() {
+  const { accountType } = await requireAuthenticatedUser();
+  const canAccess = accountType ? allowedAccountTypes.includes(accountType) : false;
+
+  if (!canAccess) {
+    return <UnauthorizedNotice />;
+  }
+
+  return <ProtectedFeaturePage featureKey="formatki" />;
+}

--- a/src/app/project/page.tsx
+++ b/src/app/project/page.tsx
@@ -1,0 +1,7 @@
+import { ProtectedFeaturePage } from "@/components/protected/ProtectedFeaturePage";
+import { requireAuthenticatedUser } from "@/lib/serverAuth";
+
+export default async function ProjectPage() {
+  await requireAuthenticatedUser();
+  return <ProtectedFeaturePage featureKey="project" />;
+}

--- a/src/app/wycena/page.tsx
+++ b/src/app/wycena/page.tsx
@@ -1,0 +1,16 @@
+import type { AccountType } from "@/lib/avatar";
+import { ProtectedFeaturePage, UnauthorizedNotice } from "@/components/protected/ProtectedFeaturePage";
+import { requireAuthenticatedUser } from "@/lib/serverAuth";
+
+const allowedAccountTypes: AccountType[] = ["admin", "carpenter"];
+
+export default async function WycenaPage() {
+  const { accountType } = await requireAuthenticatedUser();
+  const canAccess = accountType ? allowedAccountTypes.includes(accountType) : false;
+
+  if (!canAccess) {
+    return <UnauthorizedNotice />;
+  }
+
+  return <ProtectedFeaturePage featureKey="wycena" />;
+}

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -13,7 +13,19 @@ import { translations } from "@/lib/i18n";
 
 import { UserAvatar } from "./UserAvatar";
 
-type NavigationKey = "meble" | "pomieszczenie" | "wycena" | "formatki" | "play";
+type NavigationKey =
+  | "meble"
+  | "pomieszczenie"
+  | "wycena"
+  | "formatki"
+  | "play"
+  | "project";
+
+type PanelKey = "meble" | "pomieszczenie";
+
+type AuthenticatedNavigationItem =
+  | { key: PanelKey; type: "panel"; panel: PanelKey }
+  | { key: "wycena" | "formatki" | "project"; type: "link"; href: string };
 
 type NavigationLink = {
   href: string;
@@ -42,6 +54,7 @@ export default function AppHeader() {
   );
   const [user, setUser] = useState<User | null>(null);
   const [accountType, setAccountType] = useState<AccountType | null>(null);
+  const [activePanel, setActivePanel] = useState<PanelKey | null>(null);
 
   useEffect(() => {
     if (!supabase) {
@@ -128,6 +141,62 @@ export default function AppHeader() {
   }, [supabase]);
 
   const isAuthenticated = Boolean(user);
+  const canAccessRestrictedPages =
+    accountType === "admin" || accountType === "carpenter";
+  const authenticatedNavigationItems: AuthenticatedNavigationItem[] = useMemo(
+    () => {
+      const base: AuthenticatedNavigationItem[] = [
+        { key: "meble", panel: "meble", type: "panel" },
+        { key: "pomieszczenie", panel: "pomieszczenie", type: "panel" },
+      ];
+
+      if (canAccessRestrictedPages) {
+        base.push({ href: "/wycena", key: "wycena", type: "link" });
+        base.push({ href: "/formatki", key: "formatki", type: "link" });
+      }
+
+      base.push({ href: "/project", key: "project", type: "link" });
+
+      return base;
+    },
+    [canAccessRestrictedPages],
+  );
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setActivePanel(null);
+    }
+  }, [isAuthenticated]);
+  useEffect(() => {
+    if (!activePanel) {
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setActivePanel(null);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    if (typeof document !== "undefined") {
+      const originalOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+
+      return () => {
+        document.body.style.overflow = originalOverflow;
+        window.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activePanel]);
   const accountTypeIcon = getAccountTypeIcon(accountType);
   const avatarFallbackIcon = (
     <span aria-hidden="true" className="text-base">
@@ -135,41 +204,82 @@ export default function AppHeader() {
     </span>
   );
   const avatarInitial = user?.email?.[0]?.toUpperCase() ?? undefined;
-  const { header, navigation } = translations[language];
+  const { header, navigation, authenticatedNavigation, sections } =
+    translations[language];
+
+  const activePanelContent = activePanel ? sections[activePanel] : null;
+  const closePanelLabel = language === "pl" ? "Zamknij panel" : "Close panel";
 
   return (
-    <header className="border-b border-black/10 bg-white/80 px-4 py-4 backdrop-blur-sm dark:border-white/10 dark:bg-neutral-900/80">
-      <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-6">
-        <div className="flex items-center gap-6">
-          <Link
-            className="text-lg font-semibold tracking-tight text-black transition hover:text-black/70 dark:text-white dark:hover:text-white/80"
-            href="/"
-          >
-            {header.brand}
-          </Link>
+    <>
+      <header className="border-b border-black/10 bg-white/80 px-4 py-4 backdrop-blur-sm dark:border-white/10 dark:bg-neutral-900/80">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-6">
+          <div className="flex items-center gap-6">
+            <Link
+              className="text-lg font-semibold tracking-tight text-black transition hover:text-black/70 dark:text-white dark:hover:text-white/80"
+              href="/"
+            >
+              {header.brand}
+            </Link>
           <nav className="flex items-center gap-3 text-sm font-medium text-black/70 dark:text-white/70">
-            {navigationLinks.map((item) => (
-              <Link
-                key={item.key}
-                className="rounded-full px-3 py-1 capitalize transition hover:bg-black/5 hover:text-black dark:hover:bg-white/10 dark:hover:text-white"
-                href={item.href}
-              >
-                <span className="flex items-center gap-1">
-                  {navigation[item.key]}
-                  {item.withIcon ? (
-                    <span aria-hidden="true" className="text-xs">
-                      ▶
+            {isAuthenticated
+              ? authenticatedNavigationItems.map((item) => {
+                  if (item.type === "panel") {
+                    const isActive = activePanel === item.panel;
+
+                    return (
+                      <button
+                        key={item.key}
+                        aria-expanded={isActive}
+                        className={`rounded-full px-3 py-1 capitalize transition hover:bg-black/5 hover:text-black dark:hover:bg-white/10 dark:hover:text-white ${
+                          isActive
+                            ? "bg-black/10 text-black dark:bg-white/10 dark:text-white"
+                            : ""
+                        }`}
+                        onClick={() =>
+                          setActivePanel((current) =>
+                            current === item.panel ? null : item.panel,
+                          )
+                        }
+                        type="button"
+                      >
+                        {authenticatedNavigation[item.key]}
+                      </button>
+                    );
+                  }
+
+                  return (
+                    <Link
+                      key={item.key}
+                      className="rounded-full px-3 py-1 capitalize transition hover:bg-black/5 hover:text-black dark:hover:bg-white/10 dark:hover:text-white"
+                      href={item.href}
+                    >
+                      {authenticatedNavigation[item.key]}
+                    </Link>
+                  );
+                })
+              : navigationLinks.map((item) => (
+                  <Link
+                    key={item.key}
+                    className="rounded-full px-3 py-1 capitalize transition hover:bg-black/5 hover:text-black dark:hover:bg-white/10 dark:hover:text-white"
+                    href={item.href}
+                  >
+                    <span className="flex items-center gap-1">
+                      {navigation[item.key]}
+                      {item.withIcon ? (
+                        <span aria-hidden="true" className="text-xs">
+                          ▶
+                        </span>
+                      ) : null}
                     </span>
-                  ) : null}
-                </span>
-              </Link>
-            ))}
+                  </Link>
+                ))}
           </nav>
-        </div>
-        <div className="flex items-center gap-3 text-sm font-medium">
-          <LanguageSwitcher />
-          {isAuthenticated ? (
-            <Link href="/dashboard" className="rounded-full">
+          </div>
+          <div className="flex items-center gap-3 text-sm font-medium">
+            <LanguageSwitcher />
+            {isAuthenticated ? (
+              <Link href="/dashboard" className="rounded-full">
               <UserAvatar
                 fallbackIcon={avatarFallbackIcon}
                 initials={avatarInitial}
@@ -193,6 +303,54 @@ export default function AppHeader() {
           )}
         </div>
       </div>
-    </header>
+      </header>
+      {isAuthenticated && activePanelContent ? (
+        <div className="fixed inset-0 z-50 flex items-stretch justify-start">
+          <button
+            aria-label={closePanelLabel}
+            className="flex-1 bg-black/40 transition hover:bg-black/50"
+            onClick={() => setActivePanel(null)}
+            type="button"
+          />
+          <aside
+            aria-modal="true"
+            className="relative flex w-full max-w-md flex-col gap-6 overflow-y-auto border-l border-black/10 bg-white p-6 shadow-xl dark:border-white/10 dark:bg-neutral-900"
+            role="dialog"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-2">
+                <span className="text-xs font-semibold uppercase tracking-widest text-black/50 dark:text-white/50">
+                  {header.brand}
+                </span>
+                <h2 className="text-2xl font-semibold tracking-tight text-black dark:text-white">
+                  {activePanelContent.title}
+                </h2>
+              </div>
+              <button
+                aria-label={closePanelLabel}
+                className="rounded-full border border-black/10 p-2 text-black transition hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:bg-white/10"
+                onClick={() => setActivePanel(null)}
+                type="button"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            </div>
+            <p className="text-sm text-black/70 dark:text-white/70">
+              {activePanelContent.description}
+            </p>
+            <ul className="space-y-3 text-sm text-black/80 dark:text-white/80">
+              {activePanelContent.bullets.map((bullet) => (
+                <li key={bullet} className="flex items-start gap-2">
+                  <span aria-hidden="true" className="mt-1 text-xs text-black/40 dark:text-white/40">
+                    •
+                  </span>
+                  <span>{bullet}</span>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/src/components/protected/ProtectedFeaturePage.tsx
+++ b/src/components/protected/ProtectedFeaturePage.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+
+import { useLanguage } from "@/components/providers/LanguageProvider";
+import { translations } from "@/lib/i18n";
+
+type FeatureKey = "wycena" | "formatki" | "project";
+
+type ProtectedFeaturePageProps = {
+  featureKey: FeatureKey;
+};
+
+export function ProtectedFeaturePage({ featureKey }: ProtectedFeaturePageProps) {
+  const { language } = useLanguage();
+  const { protectedPages } = translations[language];
+  const feature = protectedPages.features[featureKey];
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-12 px-4 py-16">
+      <section className="space-y-4 text-center md:text-left">
+        <span className="inline-flex items-center justify-center rounded-full border border-black/10 px-4 py-1 text-xs font-medium uppercase tracking-widest text-black/70 dark:border-white/20 dark:text-white/70">
+          {protectedPages.badge}
+        </span>
+        <div className="space-y-4">
+          <h1 className="text-4xl font-semibold tracking-tight text-black dark:text-white sm:text-5xl">
+            {feature.title}
+          </h1>
+          <p className="text-base text-black/70 dark:text-white/70 sm:text-lg">
+            {feature.description}
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {feature.highlights.map((highlight) => (
+          <article
+            key={highlight}
+            className="rounded-2xl border border-black/10 bg-white p-6 text-left shadow-sm transition hover:-translate-y-1 hover:shadow-md dark:border-white/10 dark:bg-neutral-900"
+          >
+            <p className="text-sm text-black/70 dark:text-white/70">{highlight}</p>
+          </article>
+        ))}
+      </section>
+
+      <div>
+        <Link
+          className="inline-flex items-center justify-center rounded-full bg-black px-6 py-3 text-sm font-medium text-white shadow transition hover:bg-black/80 dark:bg-white dark:text-black dark:hover:bg-white/80"
+          href="/dashboard"
+        >
+          {feature.callToAction}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export function UnauthorizedNotice() {
+  const { language } = useLanguage();
+  const { protectedPages } = translations[language];
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-1 flex-col items-center justify-center px-4 py-16">
+      <div className="w-full space-y-6 rounded-2xl border border-black/10 bg-white p-8 text-center shadow-sm dark:border-white/10 dark:bg-neutral-900">
+        <h1 className="text-2xl font-semibold tracking-tight text-black dark:text-white">
+          {protectedPages.unauthorizedTitle}
+        </h1>
+        <p className="text-sm text-black/70 dark:text-white/70">
+          {protectedPages.unauthorizedDescription}
+        </p>
+        <Link
+          className="inline-flex items-center justify-center rounded-full bg-black px-6 py-3 text-sm font-medium text-white transition hover:bg-black/80 dark:bg-white dark:text-black dark:hover:bg-white/80"
+          href="/dashboard"
+        >
+          {protectedPages.goBackCta}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -7,6 +7,25 @@ type SectionContent = {
   imageAlt: string;
 };
 
+type ProtectedFeatureContent = {
+  title: string;
+  description: string;
+  highlights: string[];
+  callToAction: string;
+};
+
+type ProtectedPagesContent = {
+  badge: string;
+  unauthorizedTitle: string;
+  unauthorizedDescription: string;
+  goBackCta: string;
+  features: {
+    wycena: ProtectedFeatureContent;
+    formatki: ProtectedFeatureContent;
+    project: ProtectedFeatureContent;
+  };
+};
+
 type Translations = {
   navigation: {
     meble: string;
@@ -14,6 +33,13 @@ type Translations = {
     wycena: string;
     formatki: string;
     play: string;
+  };
+  authenticatedNavigation: {
+    meble: string;
+    pomieszczenie: string;
+    wycena: string;
+    formatki: string;
+    project: string;
   };
   header: {
     login: string;
@@ -83,6 +109,7 @@ type Translations = {
     rights: string;
     cta: string;
   };
+  protectedPages: ProtectedPagesContent;
 };
 
 export const translations: Record<Language, Translations> = {
@@ -93,6 +120,13 @@ export const translations: Record<Language, Translations> = {
       wycena: "wycena",
       formatki: "formatki",
       play: "zobacz demo",
+    },
+    authenticatedNavigation: {
+      meble: "meble",
+      pomieszczenie: "pomieszczenie",
+      wycena: "wycena",
+      formatki: "formatki",
+      project: "pokaż projekt",
     },
     header: {
       login: "Zaloguj się",
@@ -209,6 +243,48 @@ export const translations: Record<Language, Translations> = {
         imageAlt: "Lista formatek do produkcji",
       },
     },
+    protectedPages: {
+      badge: "panel roboczy",
+      unauthorizedTitle: "Brak dostępu",
+      unauthorizedDescription:
+        "Ta sekcja jest dostępna tylko dla kont administratora oraz stolarza. Skontaktuj się z właścicielem zespołu, aby rozszerzyć uprawnienia.",
+      goBackCta: "Wróć do pulpitu",
+      features: {
+        wycena: {
+          title: "Zaawansowana wycena projektów",
+          description:
+            "Zbieraj wszystkie koszty w jednym miejscu – od materiałów po robociznę – i przygotowuj ofertę gotową do wysłania klientowi.",
+          highlights: [
+            "Twórz własne cenniki materiałów i automatycznie aktualizuj marże.",
+            "Porównuj warianty ofert, aby szybko dopasować budżet do oczekiwań klienta.",
+            "Eksportuj kosztorys wraz z wizualizacjami do PDF lub CSV jednym kliknięciem.",
+          ],
+          callToAction: "Przejdź do pulpitu",
+        },
+        formatki: {
+          title: "Generator formatek produkcyjnych",
+          description:
+            "Opracuj kompletne listy cięć i obrzeży bez ręcznego liczenia – system wygeneruje je na podstawie zaakceptowanego projektu.",
+          highlights: [
+            "Przygotowuj listy elementów z podziałem na płyty, fronty i akcesoria.",
+            "Eksportuj formatki do plików CSV kompatybilnych z maszynami CNC.",
+            "Udostępniaj zestawienia ekipie produkcyjnej lub partnerom logistycznym.",
+          ],
+          callToAction: "Otwórz panel formatek",
+        },
+        project: {
+          title: "Prezentacja projektu dla klienta",
+          description:
+            "Zaprezentuj gotowy projekt w czytelnej formie, aby klient mógł przejrzeć wizualizacje, szczegóły oraz status realizacji.",
+          highlights: [
+            "Udostępniaj interaktywny widok 3D oraz wizualizacje poglądowe.",
+            "Dodawaj komentarze i aktualizacje, aby ułatwić komunikację z klientem.",
+            "Zapisuj wszystkie pliki projektu w jednym, uporządkowanym miejscu.",
+          ],
+          callToAction: "Wróć do pulpitu",
+        },
+      },
+    },
     footer: {
       rights: "Wszelkie prawa zastrzeżone.",
       cta: "Załóż konto",
@@ -221,6 +297,13 @@ export const translations: Record<Language, Translations> = {
       wycena: "pricing",
       formatki: "cut lists",
       play: "view demo",
+    },
+    authenticatedNavigation: {
+      meble: "furniture",
+      pomieszczenie: "workspace",
+      wycena: "pricing",
+      formatki: "cut lists",
+      project: "show project",
     },
     header: {
       login: "Log in",
@@ -335,6 +418,48 @@ export const translations: Record<Language, Translations> = {
           "Production schedule synchronized with your calendar",
         ],
         imageAlt: "Cut lists prepared for production",
+      },
+    },
+    protectedPages: {
+      badge: "workspace tools",
+      unauthorizedTitle: "Access restricted",
+      unauthorizedDescription:
+        "This area is available only to administrator and carpenter accounts. Contact your workspace owner if you need additional permissions.",
+      goBackCta: "Return to dashboard",
+      features: {
+        wycena: {
+          title: "Advanced project pricing",
+          description:
+            "Track every cost component—from materials to labor—and deliver a polished offer ready for your client.",
+          highlights: [
+            "Build custom material price lists and keep margins up to date automatically.",
+            "Compare offer variants to match the customer's expectations and budget.",
+            "Export estimates with visualizations to PDF or CSV in a single click.",
+          ],
+          callToAction: "Back to dashboard",
+        },
+        formatki: {
+          title: "Production cut-list generator",
+          description:
+            "Create complete cutting and edging lists without manual calculations—everything is based on the approved design.",
+          highlights: [
+            "Prepare itemized lists grouped by boards, fronts, and hardware.",
+            "Export cut lists to CNC-friendly CSV files.",
+            "Share production packages with your workshop or logistics partners.",
+          ],
+          callToAction: "Open cut-list workspace",
+        },
+        project: {
+          title: "Project presentation for clients",
+          description:
+            "Showcase the finalized design in a clear layout so clients can review visuals, details, and progress updates.",
+          highlights: [
+            "Share interactive 3D views and illustrative visualizations.",
+            "Add comments and status updates to streamline collaboration.",
+            "Store every project document in a single, organized place.",
+          ],
+          callToAction: "Return to dashboard",
+        },
       },
     },
     footer: {

--- a/src/lib/serverAuth.ts
+++ b/src/lib/serverAuth.ts
@@ -1,0 +1,41 @@
+import { redirect } from "next/navigation";
+
+import type { AccountType } from "@/lib/avatar";
+
+import { createSupabaseServerClient } from "./supabaseServer";
+
+type ProfileRow = {
+  account_type: AccountType | null;
+};
+
+export type AuthenticatedUser = {
+  id: string;
+  email: string | null;
+  accountType: AccountType | null;
+};
+
+export async function requireAuthenticatedUser(): Promise<AuthenticatedUser> {
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect("/auth/login");
+  }
+
+  const currentUser = user;
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("account_type")
+    .eq("id", currentUser.id)
+    .maybeSingle<ProfileRow>();
+
+  return {
+    id: currentUser.id,
+    email: currentUser.email ?? null,
+    accountType: profileError ? null : profile?.account_type ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- adjust the header navigation for authenticated users, showing a contextual side panel and new links
- add dedicated protected pages for pricing, cut lists, and project presentation with server-side authorization
- extend translations and introduce shared components/helpers to support the new navigation experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd29f0d58c83228bab9359313a9756