### PR TITLE
Allow owners to upgrade to carpenter

### DIFF
--- a/supabase/migrations/0008_update_profiles_lock_subscription.sql
+++ b/supabase/migrations/0008_update_profiles_lock_subscription.sql
@@ -1,0 +1,52 @@
+-- Allow profile owners to upgrade themselves to carpenters while keeping
+-- subscription locking and privilege guards in place.
+create or replace function public.profiles_lock_subscription()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  jwt_role text := current_setting('request.jwt.claim.role', true);
+  is_privileged boolean := jwt_role in ('service_role', 'supabase_admin');
+  requested_account_type public.account_type := coalesce(new.account_type, old.account_type);
+  is_owner boolean := auth.uid() = new.id;
+  allow_owner_carpenter_upgrade boolean := is_owner
+    and old.account_type = 'client'::public.account_type
+    and requested_account_type = 'carpenter'::public.account_type;
+begin
+  new.updated_at := timezone('utc', now());
+
+  if not is_privileged then
+    new.subscription_expires_at := old.subscription_expires_at;
+  elsif new.subscription_expires_at is null then
+    new.subscription_expires_at := old.subscription_expires_at;
+  end if;
+
+  if new.account_type is null then
+    new.account_type := old.account_type;
+  end if;
+
+  if not is_privileged then
+    if allow_owner_carpenter_upgrade then
+      new.account_type := 'carpenter'::public.account_type;
+    else
+      new.account_type := old.account_type;
+    end if;
+  elsif new.account_type is null then
+    new.account_type := old.account_type;
+  end if;
+
+  if not is_privileged and requested_account_type = 'admin'::public.account_type then
+    new.account_type := old.account_type;
+  end if;
+
+  return new;
+end;
+$$;
+
+-- Ensure the trigger picks up the latest definition.
+drop trigger if exists profiles_lock_subscription on public.profiles;
+create trigger profiles_lock_subscription
+  before update on public.profiles
+  for each row execute function public.profiles_lock_subscription();


### PR DESCRIPTION
## Summary
- update `profiles_lock_subscription` to let owners convert themselves from client to carpenter while keeping subscription dates locked
- keep enum defaulting and guard self-service escalation to admin roles
- recreate the trigger so the new function body is applied

## Testing
- supabase --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbe9668e08322ac2e1f10d9fa3e78