### PR TITLE
Add RPC for carpenter promotion and update signup flow

### DIFF
--- a/src/app/auth/register/SignUpForm.tsx
+++ b/src/app/auth/register/SignUpForm.tsx
@@ -176,14 +176,69 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
           return;
         }
 
-        const { error: profileError } = await supabase
-          .from("profiles")
-          .update({ account_type: accountType })
-          .eq("id", user.id);
+        if (accountType === "admin") {
+          const { data: bootstrapResult, error: bootstrapError } = await supabase.rpc(
+            "bootstrap_admin",
+            { promote: true },
+          );
 
-        if (profileError) {
-          setFormError(profileError.message);
-          return;
+          if (bootstrapError) {
+            setFormError(bootstrapError.message);
+            return;
+          }
+
+          const promoted =
+            typeof bootstrapResult === "object" &&
+            bootstrapResult !== null &&
+            "promoted" in bootstrapResult &&
+            Boolean((bootstrapResult as { promoted?: boolean }).promoted);
+
+          const adminCount =
+            typeof bootstrapResult === "object" &&
+            bootstrapResult !== null &&
+            "admin_count" in bootstrapResult
+              ? Number((bootstrapResult as { admin_count?: number }).admin_count)
+              : null;
+
+          if (!promoted) {
+            setFormError(
+              adminCount !== null && adminCount > 0
+                ? "An administrator already exists, so this account cannot be promoted."
+                : "We couldn't promote your account to administrator. Please try again.",
+            );
+            return;
+          }
+        } else if (accountType === "carpenter") {
+          const { data: promotionResult, error: promotionError } = await supabase.rpc(
+            "promote_to_carpenter",
+          );
+
+          if (promotionError) {
+            setFormError(promotionError.message);
+            return;
+          }
+
+          const nextAccountType =
+            typeof promotionResult === "object" &&
+            promotionResult !== null &&
+            "account_type" in promotionResult
+              ? (promotionResult as { account_type?: AccountType | null }).account_type ?? null
+              : null;
+
+          if (nextAccountType !== "carpenter") {
+            setFormError("We couldn't upgrade your account to carpenter. Please try again.");
+            return;
+          }
+        } else {
+          const { error: profileError } = await supabase
+            .from("profiles")
+            .update({ account_type: accountType })
+            .eq("id", user.id);
+
+          if (profileError) {
+            setFormError(profileError.message);
+            return;
+          }
         }
 
         if (invitationToken) {
@@ -195,6 +250,20 @@ export function SignUpForm({ supabase, redirectPath = "/dashboard" }: SignUpForm
             setFormError(invitationError.message);
             return;
           }
+        }
+
+        const metadataToClear: Record<string, null> = { pending_account_type: null };
+
+        if (invitationToken) {
+          metadataToClear.pending_invitation_token = null;
+        }
+
+        const { error: clearMetadataError } = await supabase.auth.updateUser({
+          data: metadataToClear,
+        });
+
+        if (clearMetadataError) {
+          console.error("Failed to clear pending metadata", clearMetadataError);
         }
 
         if (redirectPath) {

--- a/src/components/auth/VerificationHandler.tsx
+++ b/src/components/auth/VerificationHandler.tsx
@@ -195,6 +195,33 @@ export function VerificationHandler({
             );
             return;
           }
+        } else if (pendingAccountType === "carpenter") {
+          const { data: promotionResult, error: promotionError } = await supabase.rpc(
+            "promote_to_carpenter",
+          );
+
+          if (!active) {
+            return;
+          }
+
+          if (promotionError) {
+            setStatus("error");
+            setErrorMessage(promotionError.message);
+            return;
+          }
+
+          const nextAccountType =
+            typeof promotionResult === "object" &&
+            promotionResult !== null &&
+            "account_type" in promotionResult
+              ? (promotionResult as { account_type?: string | null }).account_type ?? null
+              : null;
+
+          if (nextAccountType !== "carpenter") {
+            setStatus("error");
+            setErrorMessage("We couldn't upgrade your account to carpenter. Please try again.");
+            return;
+          }
         } else {
           const { data: profile, error: profileError } = await supabase
             .from("profiles")

--- a/supabase/migrations/0010_add_carpenter_promotion_function.sql
+++ b/supabase/migrations/0010_add_carpenter_promotion_function.sql
@@ -1,0 +1,119 @@
+-- Provide an RPC that lets verified clients upgrade themselves to the carpenter
+-- role without weakening the existing profile protection triggers.
+
+create or replace function public.promote_to_carpenter()
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  caller_id uuid := auth.uid();
+  current_account_type public.account_type;
+  updated_account_type public.account_type;
+  promoted boolean := false;
+begin
+  if caller_id is null then
+    raise exception 'You must be authenticated to upgrade to the carpenter role.'
+      using errcode = '42501';
+  end if;
+
+  select account_type
+  into current_account_type
+  from public.profiles
+  where id = caller_id
+  for update;
+
+  if not found then
+    raise exception 'A profile is required before upgrading to the carpenter role.'
+      using errcode = 'P0002';
+  end if;
+
+  if current_account_type = 'carpenter'::public.account_type then
+    return json_build_object(
+      'promoted', false,
+      'account_type', current_account_type
+    );
+  end if;
+
+  if current_account_type <> 'client'::public.account_type then
+    raise exception 'Only client accounts can be upgraded to the carpenter role.'
+      using errcode = '42501';
+  end if;
+
+  perform set_config('meblomat.allow_carpenter_upgrade', 'true', true);
+
+  update public.profiles
+  set account_type = 'carpenter'::public.account_type
+  where id = caller_id
+  returning account_type into updated_account_type;
+
+  promoted := updated_account_type = 'carpenter'::public.account_type;
+
+  return json_build_object(
+    'promoted', promoted,
+    'account_type', updated_account_type
+  );
+end;
+$$;
+
+grant execute on function public.promote_to_carpenter() to authenticated, service_role;
+
+create or replace function public.profiles_lock_subscription()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  jwt_role text := current_setting('request.jwt.claim.role', true);
+  is_privileged boolean := jwt_role in ('service_role', 'supabase_admin');
+  requested_account_type public.account_type := coalesce(new.account_type, old.account_type);
+  is_owner boolean := auth.uid() = new.id;
+  allow_admin_bootstrap boolean := coalesce(current_setting('meblomat.allow_admin_bootstrap', true), 'false') = 'true';
+  allow_carpenter_upgrade_override boolean := coalesce(current_setting('meblomat.allow_carpenter_upgrade', true), 'false') = 'true';
+  allow_owner_admin_bootstrap boolean := allow_admin_bootstrap
+    and is_owner
+    and requested_account_type = 'admin'::public.account_type;
+  allow_carpenter_upgrade boolean := (
+      is_owner
+      and old.account_type = 'client'::public.account_type
+      and requested_account_type = 'carpenter'::public.account_type
+    )
+    or (
+      allow_carpenter_upgrade_override
+      and requested_account_type = 'carpenter'::public.account_type
+    );
+begin
+  new.updated_at := timezone('utc', now());
+
+  if not is_privileged then
+    new.subscription_expires_at := old.subscription_expires_at;
+  elsif new.subscription_expires_at is null then
+    new.subscription_expires_at := old.subscription_expires_at;
+  end if;
+
+  if new.account_type is null then
+    new.account_type := old.account_type;
+  end if;
+
+  if not is_privileged then
+    if allow_owner_admin_bootstrap then
+      new.account_type := 'admin'::public.account_type;
+    elsif allow_carpenter_upgrade then
+      new.account_type := 'carpenter'::public.account_type;
+    else
+      new.account_type := old.account_type;
+    end if;
+  elsif new.account_type is null then
+    new.account_type := old.account_type;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_lock_subscription on public.profiles;
+create trigger profiles_lock_subscription
+  before update on public.profiles
+  for each row execute function public.profiles_lock_subscription();


### PR DESCRIPTION
## Summary
- add a promote_to_carpenter RPC and extend the profiles trigger to honour it
- use the new RPC during signup and verification to upgrade carpenter accounts
- clear pending metadata after immediate upgrades to avoid stale account-type flags

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68ce74f22a7883228b30c4499be7d5df