### PR TITLE
Support token hash verification for invites

### DIFF
--- a/src/components/auth/VerificationHandler.test.tsx
+++ b/src/components/auth/VerificationHandler.test.tsx
@@ -1,7 +1,37 @@
-import type { AuthError } from "@supabase/supabase-js";
-import { describe, expect, it, vi } from "vitest";
+/* @vitest-environment jsdom */
 
-import { verifyEmailChangeRequest } from "./VerificationHandler";
+import type { AuthError } from "@supabase/supabase-js";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  replaceMock,
+  refreshMock,
+  isSupabaseConfiguredOnClientMock,
+  createSupabaseBrowserClientMock,
+} = vi.hoisted(() => {
+  return {
+    replaceMock: vi.fn(),
+    refreshMock: vi.fn(),
+    isSupabaseConfiguredOnClientMock: vi.fn(),
+    createSupabaseBrowserClientMock: vi.fn(),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: replaceMock,
+    refresh: refreshMock,
+  }),
+}));
+
+vi.mock("@/lib/envClient", () => ({
+  isSupabaseConfiguredOnClient: isSupabaseConfiguredOnClientMock,
+}));
+
+vi.mock("@/lib/supabaseClient", () => ({
+  createSupabaseBrowserClient: createSupabaseBrowserClientMock,
+}));
 
 describe("verifyEmailChangeRequest", () => {
   it("invokes Supabase with the provided token hash", async () => {
@@ -9,15 +39,87 @@ describe("verifyEmailChangeRequest", () => {
       data: null,
       error: null as AuthError | null,
     }));
-    const supabase = { auth: { verifyOtp } } as Parameters<
-      typeof verifyEmailChangeRequest
-    >[0];
+    const supabase = { auth: { verifyOtp } };
 
-    await verifyEmailChangeRequest(supabase, "token-hash");
+    const { verifyEmailChangeRequest } = await import("./VerificationHandler");
+
+    await verifyEmailChangeRequest(
+      supabase as Parameters<typeof verifyEmailChangeRequest>[0],
+      "token-hash",
+    );
 
     expect(verifyOtp).toHaveBeenCalledWith({
       type: "email_change",
       token_hash: "token-hash",
     });
+  });
+});
+
+describe("VerificationHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSupabaseConfiguredOnClientMock.mockReturnValue(true);
+    createSupabaseBrowserClientMock.mockReset();
+  });
+
+  it("promotes pending carpenter accounts when verifying with a token hash", async () => {
+    const verifyOtp = vi.fn(async () => ({
+      data: {
+        user: {
+          id: "user-123",
+          user_metadata: {
+            pending_account_type: "carpenter",
+          },
+        },
+      },
+      error: null,
+    }));
+    const exchangeCodeForSession = vi.fn();
+    const getUser = vi.fn();
+    const updateUser = vi.fn(async () => ({ data: null, error: null }));
+    const rpc = vi.fn(async (fn: string) => {
+      if (fn === "promote_to_carpenter") {
+        return {
+          data: { account_type: "carpenter" },
+          error: null,
+        };
+      }
+
+      return { data: null, error: null };
+    });
+
+    const supabase = {
+      auth: {
+        verifyOtp,
+        exchangeCodeForSession,
+        getUser,
+        updateUser,
+      },
+      rpc,
+    };
+
+    createSupabaseBrowserClientMock.mockReturnValue(supabase);
+
+    const { VerificationHandler } = await import("./VerificationHandler");
+
+    render(<VerificationHandler tokenHash="token-hash" type="invite" />);
+
+    await waitFor(() => {
+      expect(verifyOtp).toHaveBeenCalledWith({
+        type: "invite",
+        token_hash: "token-hash",
+      });
+    });
+
+    await waitFor(() => {
+      expect(rpc).toHaveBeenCalledWith("promote_to_carpenter");
+    });
+
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    expect(updateUser).toHaveBeenCalledWith({
+      data: { pending_account_type: null },
+    });
+    expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    expect(refreshMock).toHaveBeenCalled();
   });
 });

--- a/src/components/auth/VerificationHandler.tsx
+++ b/src/components/auth/VerificationHandler.tsx
@@ -29,6 +29,23 @@ const SUPPORTED_TYPES = new Set<SupportedVerificationType>([
   "email_change",
 ]);
 
+const TOKEN_HASH_VERIFICATION_TYPES = [
+  "signup",
+  "magiclink",
+  "invite",
+] as const;
+
+type TokenHashVerificationType = (typeof TOKEN_HASH_VERIFICATION_TYPES)[number];
+
+const TOKEN_HASH_VERIFICATION_TYPE_SET = new Set<string>(
+  TOKEN_HASH_VERIFICATION_TYPES,
+);
+
+const isTokenHashVerificationType = (
+  value: string,
+): value is TokenHashVerificationType =>
+  TOKEN_HASH_VERIFICATION_TYPE_SET.has(value);
+
 type SupabaseBrowserClient = ReturnType<typeof createSupabaseBrowserClient>;
 
 export async function verifyEmailChangeRequest(
@@ -69,13 +86,30 @@ export function VerificationHandler({
       return;
     }
 
-    if (!SUPPORTED_TYPES.has(type as SupportedVerificationType)) {
+    const verificationType = type as SupportedVerificationType;
+
+    if (!SUPPORTED_TYPES.has(verificationType)) {
       setStatus("error");
       setErrorMessage("This verification link is not valid.");
       return;
     }
 
-    if (type !== "email_change" && !code) {
+    const hasCode = Boolean(code);
+    const hasTokenHash = Boolean(tokenHash);
+    const canVerifyWithTokenHash =
+      hasTokenHash && isTokenHashVerificationType(verificationType);
+
+    if (verificationType === "email_change" && !hasCode && !hasTokenHash) {
+      setStatus("error");
+      setErrorMessage("This verification link is not valid.");
+      return;
+    }
+
+    if (
+      verificationType !== "email_change" &&
+      !hasCode &&
+      !canVerifyWithTokenHash
+    ) {
       setStatus("error");
       setErrorMessage("This verification link is not valid.");
       return;
@@ -89,7 +123,7 @@ export function VerificationHandler({
       let authError: AuthError | null = null;
       let authenticatedUser: User | null = null;
 
-      if (type === "email_change") {
+      if (verificationType === "email_change") {
         const token = tokenHash ?? code;
         if (!token) {
           setStatus("error");
@@ -107,8 +141,10 @@ export function VerificationHandler({
             authenticatedUser = session.user;
           }
         }
-      } else {
-        const exchangeResponse = await supabase.auth.exchangeCodeForSession(code!);
+      } else if (code) {
+        const exchangeResponse = await supabase.auth.exchangeCodeForSession(
+          code,
+        );
         const { data, error } = exchangeResponse;
         authError = error;
         if (!error) {
@@ -116,6 +152,21 @@ export function VerificationHandler({
 
           authenticatedUser = responseUser ?? session.user;
         }
+      } else if (tokenHash && isTokenHashVerificationType(verificationType)) {
+        const { data, error } = await supabase.auth.verifyOtp({
+          type: verificationType,
+          token_hash: tokenHash,
+        });
+        authError = error;
+        if (!error) {
+          const { user: responseUser, session } = data;
+
+          authenticatedUser = responseUser ?? session?.user ?? null;
+        }
+      } else {
+        setStatus("error");
+        setErrorMessage("This verification link is not valid.");
+        return;
       }
 
       if (!active) {


### PR DESCRIPTION
## Summary
- allow signup, magic link, and invite verifications to fall back to token hashes when no code is provided
- keep the existing account promotion logic after successful verification
- cover the token hash promotion flow with a component test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceca5bbe0c8322a1f36e5c6961615f