### PR TITLE
Improve Supabase user metadata refresh during verification

### DIFF
--- a/src/components/auth/VerificationHandler.test.tsx
+++ b/src/components/auth/VerificationHandler.test.tsx
@@ -122,4 +122,77 @@ describe("VerificationHandler", () => {
     expect(replaceMock).toHaveBeenCalledWith("/dashboard");
     expect(refreshMock).toHaveBeenCalled();
   });
+
+  it("promotes pending carpenter accounts using metadata from getUser when verifyOtp metadata is empty", async () => {
+    const verifyOtp = vi.fn(async () => ({
+      data: {
+        user: {
+          id: "user-123",
+          user_metadata: {},
+        },
+      },
+      error: null,
+    }));
+    const exchangeCodeForSession = vi.fn();
+    const getUser = vi.fn(async () => ({
+      data: {
+        user: {
+          id: "user-123",
+          user_metadata: {
+            pending_account_type: "carpenter",
+          },
+        },
+      },
+      error: null,
+    }));
+    const updateUser = vi.fn(async () => ({ data: null, error: null }));
+    const rpc = vi.fn(async (fn: string) => {
+      if (fn === "promote_to_carpenter") {
+        return {
+          data: { account_type: "carpenter" },
+          error: null,
+        };
+      }
+
+      return { data: null, error: null };
+    });
+
+    const supabase = {
+      auth: {
+        verifyOtp,
+        exchangeCodeForSession,
+        getUser,
+        updateUser,
+      },
+      rpc,
+    };
+
+    createSupabaseBrowserClientMock.mockReturnValue(supabase);
+
+    const { VerificationHandler } = await import("./VerificationHandler");
+
+    render(<VerificationHandler tokenHash="token-hash" type="invite" />);
+
+    await waitFor(() => {
+      expect(verifyOtp).toHaveBeenCalledWith({
+        type: "invite",
+        token_hash: "token-hash",
+      });
+    });
+
+    await waitFor(() => {
+      expect(getUser).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(rpc).toHaveBeenCalledWith("promote_to_carpenter");
+    });
+
+    expect(exchangeCodeForSession).not.toHaveBeenCalled();
+    expect(updateUser).toHaveBeenCalledWith({
+      data: { pending_account_type: null },
+    });
+    expect(replaceMock).toHaveBeenCalledWith("/dashboard");
+    expect(refreshMock).toHaveBeenCalled();
+  });
 });

--- a/src/components/auth/VerificationHandler.tsx
+++ b/src/components/auth/VerificationHandler.tsx
@@ -48,6 +48,26 @@ const isTokenHashVerificationType = (
 
 type SupabaseBrowserClient = ReturnType<typeof createSupabaseBrowserClient>;
 
+const getPendingAccountTypeFromUser = (user: User | null): string | null => {
+  if (!user) {
+    return null;
+  }
+
+  const value = user.user_metadata?.pending_account_type;
+
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+const getPendingInvitationTokenFromUser = (user: User | null): string | null => {
+  if (!user) {
+    return null;
+  }
+
+  const value = user.user_metadata?.pending_invitation_token;
+
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
 export async function verifyEmailChangeRequest(
   supabase: SupabaseBrowserClient,
   token: string,
@@ -179,7 +199,11 @@ export function VerificationHandler({
         return;
       }
 
-      if (!authenticatedUser) {
+      let pendingAccountType = getPendingAccountTypeFromUser(authenticatedUser);
+      let pendingInvitationToken =
+        getPendingInvitationTokenFromUser(authenticatedUser);
+
+      if (!authenticatedUser || !pendingAccountType) {
         const { data: userData, error: getUserError } = await supabase.auth.getUser();
 
         if (!active) {
@@ -192,7 +216,12 @@ export function VerificationHandler({
           return;
         }
 
-        authenticatedUser = userData?.user ?? null;
+        if (userData?.user) {
+          authenticatedUser = userData.user;
+        }
+
+        pendingAccountType = getPendingAccountTypeFromUser(authenticatedUser);
+        pendingInvitationToken = getPendingInvitationTokenFromUser(authenticatedUser);
       }
 
       if (!authenticatedUser) {
@@ -202,10 +231,6 @@ export function VerificationHandler({
         );
         return;
       }
-
-      const pendingAccountType = authenticatedUser.user_metadata?.pending_account_type;
-      const pendingInvitationToken =
-        authenticatedUser.user_metadata?.pending_invitation_token;
 
       if (pendingAccountType) {
         if (pendingAccountType === "admin") {


### PR DESCRIPTION
## Summary
- ensure the verification handler refreshes user metadata with `auth.getUser` when the pending account type is missing after OTP verification
- reuse helpers to read pending metadata before deciding on promotions and cleanup
- cover the metadata refresh scenario with a dedicated VerificationHandler test

## Testing
- npm test -- VerificationHandler

------
https://chatgpt.com/codex/tasks/task_e_68ced8a5af708322a491dff0c6291b99