### PR TITLE
Refactor verification upgrades and handle manual OTP

### DIFF
--- a/src/app/auth/verify/page.test.tsx
+++ b/src/app/auth/verify/page.test.tsx
@@ -18,15 +18,16 @@ const {
   createSupabaseBrowserClientMock,
   getUserMock,
   verificationHandlerMock,
+  authFormMock,
 } = vi.hoisted(() => {
   const redirect = vi.fn();
   const replace = vi.fn();
   const refresh = vi.fn();
   const isSupabaseConfigured = vi.fn();
   const getUser = vi.fn();
-  const supabaseClient = { auth: { getUser } };
-  const createSupabaseBrowserClient = vi.fn(() => supabaseClient);
+  const createSupabaseBrowserClient = vi.fn();
   const verificationHandler = vi.fn();
+  const authForm = vi.fn();
 
   return {
     redirectMock: redirect,
@@ -36,6 +37,7 @@ const {
     createSupabaseBrowserClientMock: createSupabaseBrowserClient,
     getUserMock: getUser,
     verificationHandlerMock: verificationHandler,
+    authFormMock: authForm,
   };
 });
 
@@ -55,15 +57,25 @@ vi.mock("@/lib/supabaseClient", () => ({
   createSupabaseBrowserClient: createSupabaseBrowserClientMock,
 }));
 
-vi.mock("@/components/auth/VerificationHandler", () => ({
-  VerificationHandler: (props: VerificationHandlerProps) => {
-    verificationHandlerMock(props);
-    return <div data-testid="verification-handler" />;
-  },
-}));
+vi.mock("@/components/auth/VerificationHandler", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/auth/VerificationHandler")
+  >("@/components/auth/VerificationHandler");
+
+  return {
+    ...actual,
+    VerificationHandler: (props: VerificationHandlerProps) => {
+      verificationHandlerMock(props);
+      return <div data-testid="verification-handler" />;
+    },
+  };
+});
 
 vi.mock("@/components/auth/AuthForm", () => ({
-  AuthForm: () => <div data-testid="auth-form" />,
+  AuthForm: (props: unknown) => {
+    authFormMock(props);
+    return <div data-testid="auth-form" />;
+  },
 }));
 
 import VerifyPage from "./page";
@@ -74,6 +86,9 @@ describe("VerifyPage", () => {
     window.history.replaceState(null, "", "/");
     isSupabaseConfiguredMock.mockReturnValue(true);
     getUserMock.mockResolvedValue({ data: { user: null } });
+    createSupabaseBrowserClientMock.mockReturnValue({
+      auth: { getUser: getUserMock },
+    });
   });
 
   it("renders a Supabase configuration warning when env vars are missing", () => {
@@ -132,5 +147,69 @@ describe("VerifyPage", () => {
 
     expect(getUserMock).not.toHaveBeenCalled();
     expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it("promotes pending carpenter accounts when the manual OTP form completes", async () => {
+    const updateUser = vi.fn(async () => ({ data: null, error: null }));
+    const rpc = vi.fn(async (fn: string, params?: Record<string, unknown>) => {
+      if (fn === "promote_to_carpenter") {
+        return {
+          data: { account_type: "carpenter" },
+          error: null,
+        };
+      }
+
+      if (fn === "accept_carpenter_invitation") {
+        expect(params).toEqual({ invitation_token: "invite-123" });
+
+        return { data: null, error: null };
+      }
+
+      return { data: null, error: null };
+    });
+    const supabase = {
+      auth: {
+        getUser: getUserMock,
+        updateUser,
+      },
+      rpc,
+    };
+
+    createSupabaseBrowserClientMock.mockReturnValue(supabase);
+
+    render(<VerifyPage />);
+
+    const authFormProps = authFormMock.mock.calls.at(-1)?.[0] as {
+      onSignedIn?: (args: unknown) => unknown;
+    };
+
+    expect(authFormProps?.onSignedIn).toBeTypeOf("function");
+
+    await authFormProps?.onSignedIn?.({
+      session: {
+        user: {
+          id: "user-123",
+          user_metadata: {
+            pending_account_type: "carpenter",
+            pending_invitation_token: "invite-123",
+          },
+        },
+      },
+      supabase,
+    });
+
+    await waitFor(() => {
+      expect(rpc).toHaveBeenCalledWith("promote_to_carpenter");
+    });
+
+    expect(rpc).toHaveBeenCalledWith("accept_carpenter_invitation", {
+      invitation_token: "invite-123",
+    });
+    expect(updateUser).toHaveBeenCalledWith({
+      data: {
+        pending_account_type: null,
+        pending_invitation_token: null,
+      },
+    });
   });
 });

--- a/src/app/auth/verify/page.tsx
+++ b/src/app/auth/verify/page.tsx
@@ -5,7 +5,10 @@ import { useRouter } from "next/navigation";
 
 import { SupabaseEnvWarning } from "@/components/SupabaseEnvWarning";
 import { AuthForm } from "@/components/auth/AuthForm";
-import { VerificationHandler } from "@/components/auth/VerificationHandler";
+import {
+  VerificationHandler,
+  completePendingAccountUpgrades,
+} from "@/components/auth/VerificationHandler";
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
 
@@ -18,6 +21,9 @@ export default function VerifyPage() {
     type: null as string | null,
   });
   const [paramsLoaded, setParamsLoaded] = useState(false);
+  const [manualVerificationError, setManualVerificationError] = useState<
+    string | null
+  >(null);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -91,11 +97,31 @@ export default function VerifyPage() {
           If you&apos;re entering a code manually, paste it below to complete the
           process.
         </p>
+        {manualVerificationError ? (
+          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm/6 text-red-900">
+            <p className="font-medium">We couldn&apos;t verify your request.</p>
+            <p className="mt-1 text-sm/5">{manualVerificationError}</p>
+          </div>
+        ) : null}
         <AuthForm
           view="verify_otp"
           className="space-y-4"
           showLinks={false}
           disableEmailRedirect
+          onSignedIn={async ({ session, supabase }) => {
+            const result = await completePendingAccountUpgrades(
+              supabase,
+              session.user,
+            );
+
+            if (result.status === "error") {
+              setManualVerificationError(result.message);
+              return false;
+            }
+
+            setManualVerificationError(null);
+            return true;
+          }}
         />
       </div>
     </div>

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
+import type { Session } from "@supabase/supabase-js";
 
 import { isSupabaseConfiguredOnClient } from "@/lib/envClient";
 import { createSupabaseBrowserClient } from "@/lib/supabaseClient";
@@ -16,6 +17,13 @@ type AuthView =
   | "update_password"
   | "verify_otp";
 
+type SupabaseBrowserClient = ReturnType<typeof createSupabaseBrowserClient>;
+
+type OnSignedInCallback = (args: {
+  session: Session;
+  supabase: SupabaseBrowserClient;
+}) => Promise<boolean | void> | boolean | void;
+
 type Props = {
   view: AuthView;
   redirectPath?: string;
@@ -23,6 +31,7 @@ type Props = {
   showLinks?: boolean;
   className?: string;
   disableEmailRedirect?: boolean;
+  onSignedIn?: OnSignedInCallback;
 };
 
 export function AuthForm({
@@ -32,6 +41,7 @@ export function AuthForm({
   showLinks = true,
   className,
   disableEmailRedirect = false,
+  onSignedIn,
 }: Props) {
   const router = useRouter();
   const isSupabaseConfigured = isSupabaseConfiguredOnClient();
@@ -64,23 +74,46 @@ export function AuthForm({
       return;
     }
 
-    const { data } = supabase.auth.onAuthStateChange((event) => {
-      if (event === "SIGNED_IN" || event === "USER_UPDATED") {
-        if (redirectPath) {
-          router.replace(redirectPath);
-        }
-        router.refresh();
-      }
+    const { data } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        if (event === "SIGNED_IN" || event === "USER_UPDATED") {
+          let allowRedirect = true;
 
-      if (event === "SIGNED_OUT") {
-        router.refresh();
-      }
-    });
+          if (event === "SIGNED_IN" && session && onSignedIn) {
+            try {
+              const result = await onSignedIn({
+                session,
+                supabase,
+              });
+
+              if (result === false) {
+                allowRedirect = false;
+              }
+            } catch (error) {
+              console.error("Failed to handle signed-in callback", error);
+            }
+          }
+
+          if (allowRedirect) {
+            if (redirectPath) {
+              router.replace(redirectPath);
+            }
+            router.refresh();
+          }
+
+          return;
+        }
+
+        if (event === "SIGNED_OUT") {
+          router.refresh();
+        }
+      },
+    );
 
     return () => {
       data.subscription.unsubscribe();
     };
-  }, [redirectPath, router, supabase]);
+  }, [onSignedIn, redirectPath, router, supabase]);
 
   if (!supabase) {
     return null;

--- a/src/components/auth/VerificationHandler.tsx
+++ b/src/components/auth/VerificationHandler.tsx
@@ -68,6 +68,158 @@ const getPendingInvitationTokenFromUser = (user: User | null): string | null => 
   return typeof value === "string" && value.length > 0 ? value : null;
 };
 
+type AccountUpgradeResult =
+  | { status: "success"; user: User }
+  | { status: "error"; message: string };
+
+export async function completePendingAccountUpgrades(
+  supabase: SupabaseBrowserClient,
+  initialUser: User | null,
+): Promise<AccountUpgradeResult> {
+  let authenticatedUser: User | null = initialUser;
+  let pendingAccountType = getPendingAccountTypeFromUser(authenticatedUser);
+  let pendingInvitationToken =
+    getPendingInvitationTokenFromUser(authenticatedUser);
+
+  if (!authenticatedUser || !pendingAccountType) {
+    const { data: userData, error: getUserError } = await supabase.auth.getUser();
+
+    if (getUserError) {
+      return { status: "error", message: getUserError.message };
+    }
+
+    if (userData?.user) {
+      authenticatedUser = userData.user;
+    }
+
+    pendingAccountType = getPendingAccountTypeFromUser(authenticatedUser);
+    pendingInvitationToken = getPendingInvitationTokenFromUser(authenticatedUser);
+  }
+
+  if (!authenticatedUser) {
+    return {
+      status: "error",
+      message:
+        "We couldn't load your account after verifying. Please try signing in again.",
+    };
+  }
+
+  if (pendingAccountType) {
+    if (pendingAccountType === "admin") {
+      const { data: bootstrapResult, error: bootstrapError } = await supabase.rpc(
+        "bootstrap_admin",
+        { promote: true },
+      );
+
+      if (bootstrapError) {
+        return { status: "error", message: bootstrapError.message };
+      }
+
+      const promoted =
+        typeof bootstrapResult === "object" &&
+        bootstrapResult !== null &&
+        "promoted" in bootstrapResult &&
+        Boolean((bootstrapResult as { promoted?: boolean }).promoted);
+
+      const adminCount =
+        typeof bootstrapResult === "object" &&
+        bootstrapResult !== null &&
+        "admin_count" in bootstrapResult
+          ? Number((bootstrapResult as { admin_count?: number }).admin_count)
+          : null;
+
+      if (!promoted) {
+        return {
+          status: "error",
+          message:
+            adminCount !== null && adminCount > 0
+              ? "An administrator already exists, so this link can no longer grant admin access."
+              : "We couldn't promote your account to administrator. Please try again.",
+        };
+      }
+    } else if (pendingAccountType === "carpenter") {
+      const { data: promotionResult, error: promotionError } = await supabase.rpc(
+        "promote_to_carpenter",
+      );
+
+      if (promotionError) {
+        return { status: "error", message: promotionError.message };
+      }
+
+      const nextAccountType =
+        typeof promotionResult === "object" &&
+        promotionResult !== null &&
+        "account_type" in promotionResult
+          ? (promotionResult as { account_type?: string | null }).account_type ?? null
+          : null;
+
+      if (nextAccountType !== "carpenter") {
+        return {
+          status: "error",
+          message:
+            "We couldn't upgrade your account to carpenter. Please try again.",
+        };
+      }
+    } else {
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("account_type")
+        .eq("id", authenticatedUser.id)
+        .single();
+
+      if (profileError) {
+        return { status: "error", message: profileError.message };
+      }
+
+      if (profile?.account_type !== pendingAccountType) {
+        const { error: updateProfileError } = await supabase
+          .from("profiles")
+          .update({ account_type: pendingAccountType })
+          .eq("id", authenticatedUser.id);
+
+        if (updateProfileError) {
+          return { status: "error", message: updateProfileError.message };
+        }
+      }
+    }
+  }
+
+  if (pendingInvitationToken) {
+    const { error: invitationError } = await supabase.rpc(
+      "accept_carpenter_invitation",
+      { invitation_token: pendingInvitationToken },
+    );
+
+    if (invitationError) {
+      return { status: "error", message: invitationError.message };
+    }
+  }
+
+  if (pendingAccountType || pendingInvitationToken) {
+    const metadataToClear: Record<string, null> = {};
+
+    if (pendingAccountType) {
+      metadataToClear.pending_account_type = null;
+    }
+
+    if (pendingInvitationToken) {
+      metadataToClear.pending_invitation_token = null;
+    }
+
+    if (Object.keys(metadataToClear).length > 0) {
+      const { error: updateUserError } = await supabase.auth.updateUser({
+        data: metadataToClear,
+      });
+
+      if (updateUserError) {
+        console.error("Failed to clear pending metadata", updateUserError);
+      }
+    }
+  }
+
+  return { status: "success", user: authenticatedUser };
+}
+
 export async function verifyEmailChangeRequest(
   supabase: SupabaseBrowserClient,
   token: string,
@@ -199,183 +351,22 @@ export function VerificationHandler({
         return;
       }
 
-      let pendingAccountType = getPendingAccountTypeFromUser(authenticatedUser);
-      let pendingInvitationToken =
-        getPendingInvitationTokenFromUser(authenticatedUser);
+      const upgradeResult = await completePendingAccountUpgrades(
+        supabase,
+        authenticatedUser,
+      );
 
-      if (!authenticatedUser || !pendingAccountType) {
-        const { data: userData, error: getUserError } = await supabase.auth.getUser();
-
-        if (!active) {
-          return;
-        }
-
-        if (getUserError) {
-          setStatus("error");
-          setErrorMessage(getUserError.message);
-          return;
-        }
-
-        if (userData?.user) {
-          authenticatedUser = userData.user;
-        }
-
-        pendingAccountType = getPendingAccountTypeFromUser(authenticatedUser);
-        pendingInvitationToken = getPendingInvitationTokenFromUser(authenticatedUser);
-      }
-
-      if (!authenticatedUser) {
-        setStatus("error");
-        setErrorMessage(
-          "We couldn't load your account after verifying. Please try signing in again.",
-        );
+      if (!active) {
         return;
       }
 
-      if (pendingAccountType) {
-        if (pendingAccountType === "admin") {
-          const { data: bootstrapResult, error: bootstrapError } = await supabase.rpc(
-            "bootstrap_admin",
-            { promote: true },
-          );
-
-          if (!active) {
-            return;
-          }
-
-          if (bootstrapError) {
-            setStatus("error");
-            setErrorMessage(bootstrapError.message);
-            return;
-          }
-
-          const promoted =
-            typeof bootstrapResult === "object" &&
-            bootstrapResult !== null &&
-            "promoted" in bootstrapResult &&
-            Boolean((bootstrapResult as { promoted?: boolean }).promoted);
-
-          const adminCount =
-            typeof bootstrapResult === "object" &&
-            bootstrapResult !== null &&
-            "admin_count" in bootstrapResult
-              ? Number((bootstrapResult as { admin_count?: number }).admin_count)
-              : null;
-
-          if (!promoted) {
-            setStatus("error");
-            setErrorMessage(
-              adminCount !== null && adminCount > 0
-                ? "An administrator already exists, so this link can no longer grant admin access."
-                : "We couldn't promote your account to administrator. Please try again.",
-            );
-            return;
-          }
-        } else if (pendingAccountType === "carpenter") {
-          const { data: promotionResult, error: promotionError } = await supabase.rpc(
-            "promote_to_carpenter",
-          );
-
-          if (!active) {
-            return;
-          }
-
-          if (promotionError) {
-            setStatus("error");
-            setErrorMessage(promotionError.message);
-            return;
-          }
-
-          const nextAccountType =
-            typeof promotionResult === "object" &&
-            promotionResult !== null &&
-            "account_type" in promotionResult
-              ? (promotionResult as { account_type?: string | null }).account_type ?? null
-              : null;
-
-          if (nextAccountType !== "carpenter") {
-            setStatus("error");
-            setErrorMessage("We couldn't upgrade your account to carpenter. Please try again.");
-            return;
-          }
-        } else {
-          const { data: profile, error: profileError } = await supabase
-            .from("profiles")
-            .select("account_type")
-            .eq("id", authenticatedUser.id)
-            .single();
-
-          if (!active) {
-            return;
-          }
-
-          if (profileError) {
-            setStatus("error");
-            setErrorMessage(profileError.message);
-            return;
-          }
-
-          if (profile?.account_type !== pendingAccountType) {
-            const { error: updateProfileError } = await supabase
-              .from("profiles")
-              .update({ account_type: pendingAccountType })
-              .eq("id", authenticatedUser.id);
-
-            if (!active) {
-              return;
-            }
-
-            if (updateProfileError) {
-              setStatus("error");
-              setErrorMessage(updateProfileError.message);
-              return;
-            }
-          }
-        }
+      if (upgradeResult.status === "error") {
+        setStatus("error");
+        setErrorMessage(upgradeResult.message);
+        return;
       }
 
-      if (pendingInvitationToken) {
-        const { error: invitationError } = await supabase.rpc(
-          "accept_carpenter_invitation",
-          { invitation_token: pendingInvitationToken },
-        );
-
-        if (!active) {
-          return;
-        }
-
-        if (invitationError) {
-          setStatus("error");
-          setErrorMessage(invitationError.message);
-          return;
-        }
-      }
-
-      if (pendingAccountType || pendingInvitationToken) {
-        const metadataToClear: Record<string, null> = {};
-
-        if (pendingAccountType) {
-          metadataToClear.pending_account_type = null;
-        }
-
-        if (pendingInvitationToken) {
-          metadataToClear.pending_invitation_token = null;
-        }
-
-        if (Object.keys(metadataToClear).length > 0) {
-          const { error: updateUserError } = await supabase.auth.updateUser({
-            data: metadataToClear,
-          });
-
-          if (!active) {
-            return;
-          }
-
-          if (updateUserError) {
-            console.error("Failed to clear pending metadata", updateUserError);
-          }
-        }
-      }
+      authenticatedUser = upgradeResult.user;
 
       setStatus("idle");
       router.replace(redirectPath);


### PR DESCRIPTION
## Summary
- extract shared helper for completing pending account upgrades and reuse it from the verification handler
- allow AuthForm to run custom callbacks on sign-in and surface manual verification errors in the verify page
- add coverage ensuring manual OTP submissions trigger carpenter promotion RPCs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceea779b848322b77133120585995c