### PR TITLE
Add Supabase authentication flow with role-specific onboarding

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,36 +1,56 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Meblomat – panel warsztatu z logowaniem Supabase
 
-## Getting Started
+Interfejs Next.js zbudowany na potrzeby zarządzania warsztatem stolarskim. Repozytorium zawiera pełny dashboard oraz system
+logowania/rejestracji oparty o Supabase z rozróżnieniem ról (administrator, stolarz, klient) i planów subskrypcyjnych.
 
-First, run the development server:
+## Wymagane zmienne środowiskowe
+
+Utwórz plik `.env.local` w katalogu `web/` i uzupełnij go o dane swojego projektu Supabase:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+# URL aplikacji używany do generowania linków afiliacyjnych
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Opcjonalnie – wymagane, jeśli chcesz wysyłać zaproszenia e-mail z uprawnieniami administratora Supabase
+SUPABASE_SERVICE_ROLE_KEY=...
+```
+
+Po zmianie wartości uruchom `npm install` w katalogu `web/`, aby zainstalować zależności Supabase.
+
+## Uruchamianie projektu
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Domyślnie aplikacja nasłuchuje na porcie `3000`. Po uruchomieniu odwiedź `http://localhost:3000`, aby zobaczyć panel. Jeśli nie
+jesteś zalogowany, zostaniesz przekierowany na `/login`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Role i plany kont
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- **Administrator** – konta tworzone ręcznie w Supabase (ustaw `role: "admin"` w `user_metadata`).
+- **Stolarz** – podczas rejestracji otrzymuje plan `carpenter_professional`, automatyczny kod afiliacyjny oraz sekcję w dashboardzie z linkiem do udostępniania.
+- **Klient** – może wybrać plan `client_free` (limit wysyłek do 2 stolarzy) lub `client_premium` (brak limitu). Informacje o planie i limicie są prezentowane po zalogowaniu.
 
-## Learn More
+Supabase przechowuje powyższe informacje w `user_metadata`, dzięki czemu można je wykorzystywać w politykach RLS lub automatyzacji w bazie.
 
-To learn more about Next.js, take a look at the following resources:
+## Integracja z bazą danych
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Dashboard korzysta z Prisma i łączy się z bazą (np. Supabase Postgres). Po skonfigurowaniu zmiennej `DATABASE_URL` i wykonaniu migracji:
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+```bash
+npx prisma migrate deploy
+```
 
-## Deploy on Vercel
+dane zaczną być pobierane bezpośrednio z bazy. Do momentu migracji panel prezentuje dane przykładowe.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Kolejne kroki
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. **Zaproszenia e-mail** – po ustawieniu `SUPABASE_SERVICE_ROLE_KEY` dodaj akcję serwerową wykorzystującą `supabase.auth.admin.inviteUserByEmail`, aby stolarze mogli wysyłać zaproszenia bezpośrednio z panelu.
+2. **Płatności** – podłącz wybrany procesor (np. Stripe) i aktualizuj `user_metadata.subscriptionPlan` po zmianie planu.
+3. **Uprawnienia RLS** – na podstawie pola `role` zdefiniuj polityki bezpieczeństwa w tabelach Supabase.
+
+Dokumentacja Supabase: https://supabase.com/docs
+

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "5.10.0",
-        "@supabase/auth-helpers-nextjs": "0.10.0",
+        "@supabase/ssr": "0.5.0",
         "@supabase/supabase-js": "2.48.1",
         "next": "15.5.4",
         "react": "19.1.0",
@@ -980,6 +980,19 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -993,33 +1006,6 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@supabase/auth-helpers-nextjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
-      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-helpers-shared": "0.7.0",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-shared": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
-      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.14.4"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.67.3",
@@ -1070,6 +1056,21 @@
         "@types/phoenix": "^1.5.4",
         "@types/ws": "^8.5.10",
         "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.5.0.tgz",
+      "integrity": "sha512-5E0NmPpfXBzfATgYhg7o/nPkVu+38mx7pO5vlhxnk/5sYGnIZcpMHJs3jONb7Jx5IJN2kTPb59luEw66MOOTaA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.6.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.9.5"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
       }
     },
     "node_modules/@supabase/storage-js": {
@@ -2469,6 +2470,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4200,15 +4210,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5379,12 +5380,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "5.10.0",
+        "@supabase/auth-helpers-nextjs": "0.10.0",
+        "@supabase/supabase-js": "2.48.1",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -959,6 +962,24 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.10.0.tgz",
+      "integrity": "sha512-JQqKYpKplsAaPDk0RVKBsN4ly6AWJys6Hkjh9PJMgtdY0IME1C0aHckyGUhHpenmOO2J6liPDDm1svSrzce8BQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -972,6 +993,107 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
+      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.7.0",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
+      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.14.4"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.67.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
+      "integrity": "sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.18.1.tgz",
+      "integrity": "sha512-dWDnoC0MoDHKhaEOrsEKTadWQcBNknZVQcSgNE/Q2wXh05mhCL1ut/jthRUrSbYcqIw/CEjhaeIPp7dLarT0bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.48.1.tgz",
+      "integrity": "sha512-VMD+CYk/KxfwGbI4fqwSUVA7CLr1izXpqfFerhnYPSi6LEKD8GoR4kuO5Cc8a+N43LnfSQwLJu4kVm2e4etEmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.67.3",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.18.1",
+        "@supabase/realtime-js": "2.11.2",
+        "@supabase/storage-js": "2.7.1"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1294,11 +1416,16 @@
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.13",
@@ -1318,6 +1445,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4064,6 +4200,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5235,6 +5380,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -5740,6 +5891,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5900,7 +6057,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -5946,6 +6102,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6061,6 +6233,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@prisma/client": "5.10.0",
-    "@supabase/auth-helpers-nextjs": "0.10.0",
+    "@supabase/ssr": "0.5.0",
     "@supabase/supabase-js": "2.48.1",
     "next": "15.5.4",
     "react": "19.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@prisma/client": "5.10.0",
+    "@supabase/auth-helpers-nextjs": "0.10.0",
+    "@supabase/supabase-js": "2.48.1",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/web/src/app/(auth)/login/actions.ts
+++ b/web/src/app/(auth)/login/actions.ts
@@ -54,7 +54,7 @@ export async function signInAction(_: FormState, formData: FormData): Promise<Fo
     return { status: 'error', message: 'Podaj adres e-mail i hasło.' };
   }
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const supabase = createSupabaseServerClient(cookieStore);
   const { error } = await supabase.auth.signInWithPassword({ email, password });
 
@@ -91,7 +91,7 @@ export async function signUpAction(_: FormState, formData: FormData): Promise<Fo
     return { status: 'error', message: 'Wybierz typ konta.' };
   }
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const supabase = createSupabaseServerClient(cookieStore);
 
   const metadata =
@@ -133,7 +133,7 @@ export async function signUpAction(_: FormState, formData: FormData): Promise<Fo
 }
 
 export async function signOutAction() {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const supabase = createSupabaseServerClient(cookieStore);
   await supabase.auth.signOut();
   redirect('/login');

--- a/web/src/app/(auth)/login/actions.ts
+++ b/web/src/app/(auth)/login/actions.ts
@@ -1,0 +1,142 @@
+'use server';
+
+import { randomBytes } from 'crypto';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import {
+  CarpenterSubscriptionPlan,
+  ClientSubscriptionPlan,
+  UserRole,
+} from '@/lib/domain';
+
+type FormState = {
+  status: 'idle' | 'error' | 'success';
+  message?: string;
+};
+
+const INITIAL_STATE: FormState = { status: 'idle' };
+
+function normalizeString(value: FormDataEntryValue | null): string {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return '';
+}
+
+function resolveCarpenterMetadata() {
+  const affiliateCode = randomBytes(4).toString('hex');
+  return {
+    role: UserRole.CARPENTER,
+    subscriptionPlan: CarpenterSubscriptionPlan.PROFESSIONAL,
+    affiliateCode,
+  } satisfies Record<string, unknown>;
+}
+
+function resolveClientMetadata(plan: ClientSubscriptionPlan, invitedBy?: string | null) {
+  const baseMetadata = {
+    role: UserRole.CLIENT,
+    subscriptionPlan: plan,
+    projectLimit: plan === ClientSubscriptionPlan.FREE ? 2 : null,
+  } satisfies Record<string, unknown>;
+
+  if (invitedBy) {
+    return { ...baseMetadata, invitedBy };
+  }
+  return baseMetadata;
+}
+
+export async function signInAction(_: FormState, formData: FormData): Promise<FormState> {
+  const email = normalizeString(formData.get('email'));
+  const password = normalizeString(formData.get('password'));
+
+  if (!email || !password) {
+    return { status: 'error', message: 'Podaj adres e-mail i hasło.' };
+  }
+
+  const cookieStore = cookies();
+  const supabase = createSupabaseServerClient(cookieStore);
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    return {
+      status: 'error',
+      message:
+        error.message === 'Invalid login credentials'
+          ? 'Niepoprawny e-mail lub hasło.'
+          : `Nie udało się zalogować: ${error.message}`,
+    };
+  }
+
+  redirect('/');
+  return INITIAL_STATE;
+}
+
+export async function signUpAction(_: FormState, formData: FormData): Promise<FormState> {
+  const email = normalizeString(formData.get('email'));
+  const password = normalizeString(formData.get('password'));
+  const role = normalizeString(formData.get('role'));
+  const clientPlan = normalizeString(formData.get('clientPlan'));
+  const invitedBy = normalizeString(formData.get('invitedBy')) || undefined;
+
+  if (!email || !password) {
+    return { status: 'error', message: 'Podaj adres e-mail oraz hasło.' };
+  }
+
+  if (password.length < 8) {
+    return { status: 'error', message: 'Hasło musi mieć co najmniej 8 znaków.' };
+  }
+
+  if (role !== UserRole.CARPENTER && role !== UserRole.CLIENT) {
+    return { status: 'error', message: 'Wybierz typ konta.' };
+  }
+
+  const cookieStore = cookies();
+  const supabase = createSupabaseServerClient(cookieStore);
+
+  const metadata =
+    role === UserRole.CARPENTER
+      ? resolveCarpenterMetadata()
+      : resolveClientMetadata(
+          clientPlan === ClientSubscriptionPlan.PREMIUM
+            ? ClientSubscriptionPlan.PREMIUM
+            : ClientSubscriptionPlan.FREE,
+          invitedBy,
+        );
+
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'}/auth/callback`,
+      data: metadata,
+    },
+  });
+
+  if (error) {
+    return {
+      status: 'error',
+      message: error.message.includes('already registered')
+        ? 'Adres e-mail jest już zajęty. Zaloguj się zamiast tego.'
+        : `Nie udało się utworzyć konta: ${error.message}`,
+    };
+  }
+
+  if (data.session) {
+    redirect('/');
+  }
+
+  return {
+    status: 'success',
+    message: 'Sprawdź skrzynkę e-mail i potwierdź rejestrację, aby się zalogować.',
+  };
+}
+
+export async function signOutAction() {
+  const cookieStore = cookies();
+  const supabase = createSupabaseServerClient(cookieStore);
+  await supabase.auth.signOut();
+  redirect('/login');
+}
+
+export { INITIAL_STATE };

--- a/web/src/app/(auth)/login/auth-forms.tsx
+++ b/web/src/app/(auth)/login/auth-forms.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+import { INITIAL_STATE, signInAction, signUpAction } from './actions';
+import { ClientSubscriptionPlan, UserRole } from '@/lib/domain';
+
+type AuthFormsProps = {
+  invitedBy?: string | null;
+};
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="w-full rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={pending}
+    >
+      {pending ? 'Przetwarzanie…' : label}
+    </button>
+  );
+}
+
+function ErrorMessage({ state }: { state: { status: string; message?: string } }) {
+  if (state.status !== 'error' || !state.message) {
+    return null;
+  }
+
+  return (
+    <p className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+      {state.message}
+    </p>
+  );
+}
+
+function SuccessMessage({ state }: { state: { status: string; message?: string } }) {
+  if (state.status !== 'success' || !state.message) {
+    return null;
+  }
+
+  return (
+    <p className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+      {state.message}
+    </p>
+  );
+}
+
+export function AuthForms({ invitedBy }: AuthFormsProps) {
+  const [mode, setMode] = useState<'login' | 'register'>(invitedBy ? 'register' : 'login');
+  const [loginState, loginAction] = useFormState(signInAction, INITIAL_STATE);
+  const [registerState, registerAction] = useFormState(signUpAction, INITIAL_STATE);
+
+  const invitationNotice = useMemo(() => {
+    if (!invitedBy) {
+      return null;
+    }
+    return (
+      <p className="rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-3 text-xs text-emerald-200">
+        Zostałeś zaproszony do współpracy przez stolarza o identyfikatorze <span className="font-semibold">{invitedBy}</span>.
+        Po rejestracji Twoje konto zostanie automatycznie powiązane z jego warsztatem.
+      </p>
+    );
+  }, [invitedBy]);
+
+  return (
+    <div className="mx-auto w-full max-w-xl rounded-3xl border border-white/10 bg-slate-950/80 p-8 shadow-xl shadow-black/40">
+      <div className="mb-6 flex items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => setMode('login')}
+          className={`flex-1 rounded-full px-4 py-2 text-sm font-semibold transition ${
+            mode === 'login'
+              ? 'bg-emerald-500 text-emerald-950'
+              : 'bg-white/5 text-slate-300 hover:bg-white/10 hover:text-white'
+          }`}
+        >
+          Mam konto
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('register')}
+          className={`flex-1 rounded-full px-4 py-2 text-sm font-semibold transition ${
+            mode === 'register'
+              ? 'bg-emerald-500 text-emerald-950'
+              : 'bg-white/5 text-slate-300 hover:bg-white/10 hover:text-white'
+          }`}
+        >
+          Chcę dołączyć
+        </button>
+      </div>
+
+      {mode === 'login' ? (
+        <form className="space-y-4" action={loginAction}>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              E-mail
+            </label>
+            <input
+              name="email"
+              type="email"
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Hasło
+            </label>
+            <input
+              name="password"
+              type="password"
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+          </div>
+          <ErrorMessage state={loginState} />
+          <SubmitButton label="Zaloguj się" />
+        </form>
+      ) : (
+        <form className="space-y-4" action={registerAction}>
+          <input type="hidden" name="invitedBy" value={invitedBy ?? ''} />
+          {invitationNotice}
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Adres e-mail
+            </label>
+            <input
+              name="email"
+              type="email"
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Hasło
+            </label>
+            <input
+              name="password"
+              type="password"
+              minLength={8}
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+            <p className="mt-1 text-xs text-slate-400">Minimum 8 znaków, zalecane litery i cyfry.</p>
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Typ konta
+            </label>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <label className="flex cursor-pointer flex-col rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-emerald-500/40">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Stolarz</span>
+                  <input
+                    type="radio"
+                    name="role"
+                    value={UserRole.CARPENTER}
+                    className="h-4 w-4"
+                    required
+                  />
+                </div>
+                <p className="mt-2 text-xs text-slate-300">
+                  Pełny dostęp do tworzenia projektów, wycen i panelu warsztatu. Wymagana aktywna subskrypcja.
+                </p>
+              </label>
+              <label className="flex cursor-pointer flex-col rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-emerald-500/40">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Klient</span>
+                  <input
+                    type="radio"
+                    name="role"
+                    value={UserRole.CLIENT}
+                    className="h-4 w-4"
+                    required
+                  />
+                </div>
+                <p className="mt-2 text-xs text-slate-300">
+                  Darmowe konto do wysyłania zapytań ofertowych do maksymalnie 2 stolarzy.
+                </p>
+                <div className="mt-4 space-y-2 rounded-xl bg-slate-900/60 p-3">
+                  <label className="flex items-center justify-between text-xs text-slate-200">
+                    <span>Plan standardowy</span>
+                    <input
+                      type="radio"
+                      name="clientPlan"
+                      value={ClientSubscriptionPlan.FREE}
+                      defaultChecked
+                      className="h-3 w-3"
+                    />
+                  </label>
+                  <label className="flex items-center justify-between text-xs text-slate-200">
+                    <span>Plan premium (nielimitowane zapytania)</span>
+                    <input
+                      type="radio"
+                      name="clientPlan"
+                      value={ClientSubscriptionPlan.PREMIUM}
+                      className="h-3 w-3"
+                    />
+                  </label>
+                </div>
+              </label>
+            </div>
+          </div>
+          <ErrorMessage state={registerState} />
+          <SuccessMessage state={registerState} />
+          <SubmitButton label="Utwórz konto" />
+        </form>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -15,7 +15,7 @@ type LoginPageProps = {
 };
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const supabase = createSupabaseServerClient(cookieStore);
   const {
     data: { session },

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { AuthForms } from './auth-forms';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export const metadata: Metadata = {
+  title: 'Meblomat – Logowanie i rejestracja',
+  description:
+    'Zaloguj się lub dołącz do platformy Meblomat jako stolarz lub klient. Konta integrowane z Supabase.',
+};
+
+type LoginPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const cookieStore = cookies();
+  const supabase = createSupabaseServerClient(cookieStore);
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session) {
+    redirect('/');
+  }
+
+  const params = searchParams ?? {};
+  const refParam = Array.isArray(params.ref) ? params.ref[0] : params.ref;
+  const invitedParam = Array.isArray(params.invitedBy) ? params.invitedBy[0] : params.invitedBy;
+  const invitedBy = refParam ?? invitedParam ?? null;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 px-6 py-16 text-slate-100">
+      <div className="mb-8 text-center">
+        <span className="inline-flex rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+          Meblomat
+        </span>
+        <h1 className="mt-4 text-3xl font-semibold text-white md:text-4xl">Witaj w panelu warsztatu</h1>
+        <p className="mt-2 max-w-xl text-sm text-slate-300">
+          Zaloguj się, aby zarządzać warsztatem stolarskim, lub utwórz konto klienta i wysyłaj swoje projekty do wyceny.
+        </p>
+      </div>
+      <AuthForms invitedBy={invitedBy} />
+    </main>
+  );
+}

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 };
 
 type LoginPageProps = {
-  searchParams?: Record<string, string | string[] | undefined>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
@@ -25,7 +25,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     redirect('/');
   }
 
-  const params = searchParams ?? {};
+  const params = (await searchParams) ?? {};
   const refParam = Array.isArray(params.ref) ? params.ref[0] : params.ref;
   const invitedParam = Array.isArray(params.invitedBy) ? params.invitedBy[0] : params.invitedBy;
   const invitedBy = refParam ?? invitedParam ?? null;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -18,7 +18,7 @@ import { getDashboardData } from '@/server/dashboard';
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const supabase = createSupabaseServerClient(cookieStore);
   const {
     data: { session },

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,13 +1,40 @@
 import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import { DatabaseStatusCard } from '@/components/database-status-card';
+import { CopyField } from '@/components/copy-field';
 import { OrderPriorityBadge, OrderStatusBadge } from '@/components/order-status-pill';
 import { OrdersPipeline } from '@/components/orders-pipeline';
+import { SignOutButton } from '@/components/sign-out-button';
+import {
+  ClientSubscriptionPlan,
+  UserRole,
+} from '@/lib/domain';
 import { formatCurrency, formatDateShort, formatPhone, formatRelativeDays } from '@/lib/format';
+import { getSiteUrl } from '@/lib/supabase/config';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getDashboardData } from '@/server/dashboard';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
+  const cookieStore = cookies();
+  const supabase = createSupabaseServerClient(cookieStore);
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  const metadata = (session.user.user_metadata ?? {}) as Record<string, unknown>;
+  const userRole = (metadata.role as string) ?? UserRole.CLIENT;
+  const subscriptionPlan = metadata.subscriptionPlan as string | undefined;
+  const projectLimit = typeof metadata.projectLimit === 'number' ? metadata.projectLimit : null;
+  const affiliateCode = typeof metadata.affiliateCode === 'string' ? metadata.affiliateCode : null;
+  const invitedBy = typeof metadata.invitedBy === 'string' ? metadata.invitedBy : null;
+
   const dashboard = await getDashboardData();
   const stats = [
     {
@@ -36,11 +63,40 @@ export default async function Home() {
   const topCarpenters = dashboard.carpenters.slice(0, 4);
   const topClients = dashboard.clients.slice(0, 6);
 
+  const siteUrl = getSiteUrl().replace(/\/$/, '');
+  const affiliateLink = `${siteUrl}/login?ref=${affiliateCode ?? session.user.id}`;
+
+  const roleLabel =
+    userRole === UserRole.ADMIN
+      ? 'Administrator'
+      : userRole === UserRole.CARPENTER
+        ? 'Stolarz'
+        : 'Klient';
+
+  let planLabel = 'Pełny dostęp';
+  if (userRole === UserRole.CARPENTER) {
+    planLabel = 'Subskrypcja warsztatu';
+  } else if (userRole === UserRole.CLIENT) {
+    planLabel =
+      subscriptionPlan === ClientSubscriptionPlan.PREMIUM
+        ? 'Klient premium'
+        : 'Klient standardowy';
+  }
+
+  const remainingRequestsLabel =
+    userRole === UserRole.CLIENT
+      ? subscriptionPlan === ClientSubscriptionPlan.PREMIUM
+        ? 'Brak limitów wysyłki projektów.'
+        : projectLimit !== null
+          ? `Możesz wysłać projekty do ${projectLimit} stolarzy jednocześnie.`
+          : 'Możesz wysłać projekty do 2 stolarzy jednocześnie.'
+      : null;
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
       <header className="border-b border-white/10 bg-slate-950/70">
         <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10 md:flex-row md:items-end md:justify-between">
-          <div>
+          <div className="space-y-6">
             <span className="inline-flex rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200">
               Meblomat
             </span>
@@ -51,6 +107,24 @@ export default async function Home() {
               Monitoruj realizację zamówień, dostępność zespołu i relacje z klientami. Gotowe do
               podpięcia pod Supabase.
             </p>
+            <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200 shadow shadow-black/30 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-slate-400">Zalogowany użytkownik</p>
+                <p className="mt-1 text-base font-semibold text-white">{session.user.email}</p>
+                <p className="mt-1 text-xs text-slate-300">
+                  Rola: {roleLabel} · Plan: {planLabel}
+                </p>
+                {invitedBy && userRole === UserRole.CLIENT ? (
+                  <p className="mt-1 text-xs text-emerald-200">
+                    Połączony ze stolarzem ID: {invitedBy}
+                  </p>
+                ) : null}
+                {remainingRequestsLabel ? (
+                  <p className="mt-2 text-xs text-slate-200">{remainingRequestsLabel}</p>
+                ) : null}
+              </div>
+              <SignOutButton />
+            </div>
           </div>
           <div className="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-100 shadow shadow-emerald-500/20">
             <p className="text-xs uppercase tracking-[0.35em] text-emerald-200">Następny krok</p>
@@ -64,6 +138,53 @@ export default async function Home() {
 
       <main className="mx-auto max-w-6xl space-y-12 px-6 py-12">
         <DatabaseStatusCard state={dashboard.connection} />
+
+        {userRole === UserRole.CARPENTER ? (
+          <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+            <div className="rounded-2xl border border-white/10 bg-emerald-500/5 p-6 shadow shadow-emerald-500/10">
+              <h2 className="text-lg font-semibold text-white">Twój link afiliacyjny</h2>
+              <p className="mt-2 text-sm text-slate-200">
+                Udostępnij ten link klientom na stronie internetowej lub w social mediach. Każda osoba, która zarejestruje się przez link,
+                zostanie przypisana do Twojego warsztatu i zobaczy Twoje oferty w panelu klienta.
+              </p>
+              <div className="mt-4">
+                <CopyField label="Kopiuj" value={affiliateLink} />
+              </div>
+              <p className="mt-3 text-xs text-slate-300">
+                Kod afiliacyjny jest generowany automatycznie w metadanych użytkownika Supabase i można go zmienić w razie potrzeby w konsoli.
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow shadow-black/30">
+              <h3 className="text-base font-semibold text-white">Zaproszenia e-mail</h3>
+              <p className="mt-2 text-sm text-slate-300">
+                Wysyłaj spersonalizowane zaproszenia klientom bezpośrednio z panelu po skonfigurowaniu funkcji serwerowej z kluczem
+                <code className="mx-1 rounded bg-slate-950/80 px-1">SUPABASE_SERVICE_ROLE_KEY</code>.
+              </p>
+              <p className="mt-3 text-xs text-slate-400">
+                Dodaj integrację z dostawcą e-mail (np. Resend) i użyj Supabase Admin API, aby automatycznie tworzyć konta klientów i wysyłać im link do
+                rejestracji.
+              </p>
+            </div>
+          </section>
+        ) : null}
+
+        {userRole === UserRole.CLIENT ? (
+          <section className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow shadow-black/30">
+            <h2 className="text-lg font-semibold text-white">Twój plan klienta</h2>
+            <p className="mt-2 text-sm text-slate-300">
+              {remainingRequestsLabel ?? 'Możesz wysyłać zapytania do stolarzy bez ograniczeń.'}
+            </p>
+            {subscriptionPlan !== ClientSubscriptionPlan.PREMIUM ? (
+              <p className="mt-3 text-xs text-slate-400">
+                Potrzebujesz więcej wysyłek? Wykup konto premium w zakładce płatności (do implementacji) lub skontaktuj się bezpośrednio ze swoim stolarzem.
+              </p>
+            ) : (
+              <p className="mt-3 text-xs text-emerald-200">
+                Konto premium aktywne – wszystkie funkcje klienta odblokowane.
+              </p>
+            )}
+          </section>
+        ) : null}
 
         <section className="space-y-6">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">

--- a/web/src/components/copy-field.tsx
+++ b/web/src/components/copy-field.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+
+type CopyFieldProps = {
+  label: string;
+  value: string;
+};
+
+export function CopyField({ label, value }: CopyFieldProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy link', error);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      <code className="flex-1 truncate rounded-xl border border-white/10 bg-slate-950/60 px-4 py-2 text-sm text-slate-200">
+        {value}
+      </code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-100 transition hover:bg-emerald-500/20"
+      >
+        {copied ? 'Skopiowano!' : label}
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/sign-out-button.tsx
+++ b/web/src/components/sign-out-button.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+import { signOutAction } from '@/app/(auth)/login/actions';
+
+function SignOutSubmit() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-red-400/40 hover:bg-red-500/10 hover:text-red-100 disabled:opacity-60"
+      disabled={pending}
+    >
+      {pending ? 'Wylogowywanie…' : 'Wyloguj'}
+    </button>
+  );
+}
+
+export function SignOutButton() {
+  return (
+    <form action={signOutAction} className="inline-flex">
+      <SignOutSubmit />
+    </form>
+  );
+}

--- a/web/src/lib/domain.ts
+++ b/web/src/lib/domain.ts
@@ -28,3 +28,26 @@ export const TaskStatus = Object.freeze({
 
 export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 export const TASK_STATUSES = Object.values(TaskStatus) as TaskStatus[];
+
+export const UserRole = Object.freeze({
+  ADMIN: 'admin',
+  CARPENTER: 'carpenter',
+  CLIENT: 'client',
+} as const);
+
+export type UserRole = (typeof UserRole)[keyof typeof UserRole];
+
+export const ClientSubscriptionPlan = Object.freeze({
+  FREE: 'client_free',
+  PREMIUM: 'client_premium',
+} as const);
+
+export type ClientSubscriptionPlan =
+  (typeof ClientSubscriptionPlan)[keyof typeof ClientSubscriptionPlan];
+
+export const CarpenterSubscriptionPlan = Object.freeze({
+  PROFESSIONAL: 'carpenter_professional',
+} as const);
+
+export type CarpenterSubscriptionPlan =
+  (typeof CarpenterSubscriptionPlan)[keyof typeof CarpenterSubscriptionPlan];

--- a/web/src/lib/supabase/client.ts
+++ b/web/src/lib/supabase/client.ts
@@ -1,4 +1,4 @@
-import { createBrowserClient } from '@supabase/auth-helpers-nextjs';
+import { createBrowserClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
 

--- a/web/src/lib/supabase/client.ts
+++ b/web/src/lib/supabase/client.ts
@@ -1,0 +1,12 @@
+import { createBrowserClient } from '@supabase/auth-helpers-nextjs';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
+
+let browserClient: SupabaseClient | undefined;
+
+export function getSupabaseBrowserClient(): SupabaseClient {
+  if (!browserClient) {
+    browserClient = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  }
+  return browserClient;
+}

--- a/web/src/lib/supabase/config.ts
+++ b/web/src/lib/supabase/config.ts
@@ -1,0 +1,17 @@
+function readEnv(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Brak wymaganej zmiennej środowiskowej ${name}. Uzupełnij konfigurację Supabase w pliku .env.local.`,
+    );
+  }
+  return value;
+}
+
+export const SUPABASE_URL = readEnv('NEXT_PUBLIC_SUPABASE_URL');
+export const SUPABASE_ANON_KEY = readEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+export function getSiteUrl() {
+  return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+}

--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -1,27 +1,27 @@
 import { cookies } from 'next/headers';
-import { createServerClient } from '@supabase/auth-helpers-nextjs';
+import type { CookieOptions } from '@supabase/ssr';
+import { createServerClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
 
-type CookieStore = ReturnType<typeof cookies>;
+type CookieStore = Awaited<ReturnType<typeof cookies>>;
 
 function createCookieAdapter(cookieStore: CookieStore) {
   return {
     get(name: string) {
       return cookieStore.get(name)?.value;
     },
-    set(name: string, value: string, options: Parameters<CookieStore['set']>[0]) {
+    set(name: string, value: string, options: CookieOptions) {
       cookieStore.set({ name, value, ...options });
     },
-    remove(name: string, options: Parameters<CookieStore['set']>[0]) {
+    remove(name: string, options: CookieOptions) {
       cookieStore.set({ name, value: '', ...options, expires: new Date(0) });
     },
   };
 }
 
-export function createSupabaseServerClient(cookieStore?: CookieStore): SupabaseClient {
-  const store = cookieStore ?? cookies();
+export function createSupabaseServerClient(cookieStore: CookieStore): SupabaseClient {
   return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-    cookies: createCookieAdapter(store),
+    cookies: createCookieAdapter(cookieStore),
   });
 }

--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -1,0 +1,27 @@
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/auth-helpers-nextjs';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
+
+type CookieStore = ReturnType<typeof cookies>;
+
+function createCookieAdapter(cookieStore: CookieStore) {
+  return {
+    get(name: string) {
+      return cookieStore.get(name)?.value;
+    },
+    set(name: string, value: string, options: Parameters<CookieStore['set']>[0]) {
+      cookieStore.set({ name, value, ...options });
+    },
+    remove(name: string, options: Parameters<CookieStore['set']>[0]) {
+      cookieStore.set({ name, value: '', ...options, expires: new Date(0) });
+    },
+  };
+}
+
+export function createSupabaseServerClient(cookieStore?: CookieStore): SupabaseClient {
+  const store = cookieStore ?? cookies();
+  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: createCookieAdapter(store),
+  });
+}


### PR DESCRIPTION
## Summary
- add Supabase client helpers and configuration along with role/subscription constants
- implement login and registration UI with server actions that persist user role metadata and redirects
- gate the dashboard behind authentication, show role-aware callouts, and surface carpenter affiliate links plus client plan info
- document Supabase environment variables and onboarding flow in the web README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55dc515248322a4756e05454e17da