### PR TITLE
Handle Supabase auth errors in server actions

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -57,6 +57,10 @@ Dashboard korzysta z Prisma i łączy się z bazą (np. Supabase Postgres). Po s
 npx prisma migrate deploy
 ```
 
+Polecenie działa zarówno z katalogu głównego repozytorium, jak i z `web/`,
+ponieważ konfiguracja `package.json` wskazuje na wspólny plik
+`../prisma/schema.prisma`.
+
 dane zaczną być pobierane bezpośrednio z bazy. Do momentu migracji panel prezentuje dane przykładowe.
 
 ## Kolejne kroki

--- a/web/README.md
+++ b/web/README.md
@@ -14,7 +14,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=...
 # URL aplikacji używany do generowania linków afiliacyjnych
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
-# Opcjonalnie – wymagane, jeśli chcesz wysyłać zaproszenia e-mail z panelu
+# Opcjonalnie – wymagane, jeśli chcesz wysyłać zaproszenia e-mail z uprawnieniami administratora Supabase
 SUPABASE_SERVICE_ROLE_KEY=...
 ```
 
@@ -35,7 +35,7 @@ jesteś zalogowany, zostaniesz przekierowany na `/login`.
 - **Stolarz** – podczas rejestracji otrzymuje plan `carpenter_professional`, automatyczny kod afiliacyjny oraz sekcję w dashboardzie z linkiem do udostępniania.
 - **Klient** – może wybrać plan `client_free` (limit wysyłek do 2 stolarzy) lub `client_premium` (brak limitu). Informacje o planie i limicie są prezentowane po zalogowaniu.
 
-Supabase przechowuje powyższe informacje w `user_metadata`, dzięki czemu można je wykorzystywać w politykach RLS lub automatyzacji w bazie.
+Supabase przechowuje powyższe informacje w `user_metadata`, dzięki czemu można je wykorzystywać w politykach RLS lub automatyzacjach w bazie.
 
 ## Zapraszanie klientów
 
@@ -46,6 +46,8 @@ Aby skorzystać z funkcji:
 1. W Supabase przejdź do ustawień projektu i skopiuj `service_role key`.
 2. W pliku `.env.local` ustaw `SUPABASE_SERVICE_ROLE_KEY` z wartością klucza.
 3. Uruchom ponownie serwer deweloperski. Formularz w panelu będzie dostępny od razu i pozwoli wybrać plan (standardowy lub premium) dla zaproszonego klienta.
+
+Możesz rozszerzyć ten proces, integrując zewnętrznego dostawcę e-mail (np. Resend) i wykorzystując Supabase Admin API do personalizowania treści zaproszeń.
 
 ## Integracja z bazą danych
 
@@ -64,4 +66,3 @@ dane zaczną być pobierane bezpośrednio z bazy. Do momentu migracji panel prez
 3. **Powiadomienia e-mail/SMS** – rozbuduj proces wysyłki zaproszeń o dodatkowe powiadomienia (np. Resend, Twilio) przy zmianach statusu zleceń.
 
 Dokumentacja Supabase: https://supabase.com/docs
-

--- a/web/README.md
+++ b/web/README.md
@@ -1,36 +1,56 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Meblomat – panel warsztatu z logowaniem Supabase
 
-## Getting Started
+Interfejs Next.js zbudowany na potrzeby zarządzania warsztatem stolarskim. Repozytorium zawiera pełny dashboard oraz system
+logowania/rejestracji oparty o Supabase z rozróżnieniem ról (administrator, stolarz, klient) i planów subskrypcyjnych.
 
-First, run the development server:
+## Wymagane zmienne środowiskowe
+
+Utwórz plik `.env.local` w katalogu `web/` i uzupełnij go o dane swojego projektu Supabase:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+# URL aplikacji używany do generowania linków afiliacyjnych
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Opcjonalnie – wymagane, jeśli chcesz wysyłać zaproszenia e-mail z uprawnieniami administratora Supabase
+SUPABASE_SERVICE_ROLE_KEY=...
+```
+
+Po zmianie wartości uruchom `npm install` w katalogu `web/`, aby zainstalować zależności Supabase.
+
+## Uruchamianie projektu
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Domyślnie aplikacja nasłuchuje na porcie `3000`. Po uruchomieniu odwiedź `http://localhost:3000`, aby zobaczyć panel. Jeśli nie
+jesteś zalogowany, zostaniesz przekierowany na `/login`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Role i plany kont
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- **Administrator** – konta tworzone ręcznie w Supabase (ustaw `role: "admin"` w `user_metadata`).
+- **Stolarz** – podczas rejestracji otrzymuje plan `carpenter_professional`, automatyczny kod afiliacyjny oraz sekcję w dashboardzie z linkiem do udostępniania.
+- **Klient** – może wybrać plan `client_free` (limit wysyłek do 2 stolarzy) lub `client_premium` (brak limitu). Informacje o planie i limicie są prezentowane po zalogowaniu.
 
-## Learn More
+Supabase przechowuje powyższe informacje w `user_metadata`, dzięki czemu można je wykorzystywać w politykach RLS lub automatyzacji w bazie.
 
-To learn more about Next.js, take a look at the following resources:
+## Integracja z bazą danych
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Dashboard korzysta z Prisma i łączy się z bazą (np. Supabase Postgres). Po skonfigurowaniu zmiennej `DATABASE_URL` i wykonaniu migracji:
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+```bash
+npx prisma migrate deploy
+```
 
-## Deploy on Vercel
+dane zaczną być pobierane bezpośrednio z bazy. Do momentu migracji panel prezentuje dane przykładowe.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Kolejne kroki
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. **Zaproszenia e-mail** – po ustawieniu `SUPABASE_SERVICE_ROLE_KEY` dodaj akcję serwerową wykorzystującą `supabase.auth.admin.inviteUserByEmail`, aby stolarze mogli wysyłać zaproszenia bezpośrednio z panelu.
+2. **Płatności** – podłącz wybrany procesor (np. Stripe) i aktualizuj `user_metadata.subscriptionPlan` po zmianie planu.
+3. **Uprawnienia RLS** – na podstawie pola `role` zdefiniuj polityki bezpieczeństwa w tabelach Supabase.
+
+Dokumentacja Supabase: https://supabase.com/docs
+

--- a/web/README.md
+++ b/web/README.md
@@ -2,6 +2,7 @@
 
 Interfejs Next.js zbudowany na potrzeby zarządzania warsztatem stolarskim. Repozytorium zawiera pełny dashboard oraz system
 logowania/rejestracji oparty o Supabase z rozróżnieniem ról (administrator, stolarz, klient) i planów subskrypcyjnych.
+Stolarze mają do dyspozycji automatyczne linki afiliacyjne oraz formularz zapraszania klientów przez e-mail.
 
 ## Wymagane zmienne środowiskowe
 
@@ -13,7 +14,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=...
 # URL aplikacji używany do generowania linków afiliacyjnych
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
-# Opcjonalnie – wymagane, jeśli chcesz wysyłać zaproszenia e-mail z uprawnieniami administratora Supabase
+# Opcjonalnie – wymagane, jeśli chcesz wysyłać zaproszenia e-mail z panelu
 SUPABASE_SERVICE_ROLE_KEY=...
 ```
 
@@ -36,6 +37,16 @@ jesteś zalogowany, zostaniesz przekierowany na `/login`.
 
 Supabase przechowuje powyższe informacje w `user_metadata`, dzięki czemu można je wykorzystywać w politykach RLS lub automatyzacji w bazie.
 
+## Zapraszanie klientów
+
+W panelu stolarza znajduje się formularz wysyłki zaproszeń e-mail. Po wprowadzeniu adresu klienta Supabase wysyła standardowe zaproszenie, a konto użytkownika zostaje automatycznie przypisane do warsztatu zapraszającego.
+
+Aby skorzystać z funkcji:
+
+1. W Supabase przejdź do ustawień projektu i skopiuj `service_role key`.
+2. W pliku `.env.local` ustaw `SUPABASE_SERVICE_ROLE_KEY` z wartością klucza.
+3. Uruchom ponownie serwer deweloperski. Formularz w panelu będzie dostępny od razu i pozwoli wybrać plan (standardowy lub premium) dla zaproszonego klienta.
+
 ## Integracja z bazą danych
 
 Dashboard korzysta z Prisma i łączy się z bazą (np. Supabase Postgres). Po skonfigurowaniu zmiennej `DATABASE_URL` i wykonaniu migracji:
@@ -48,9 +59,9 @@ dane zaczną być pobierane bezpośrednio z bazy. Do momentu migracji panel prez
 
 ## Kolejne kroki
 
-1. **Zaproszenia e-mail** – po ustawieniu `SUPABASE_SERVICE_ROLE_KEY` dodaj akcję serwerową wykorzystującą `supabase.auth.admin.inviteUserByEmail`, aby stolarze mogli wysyłać zaproszenia bezpośrednio z panelu.
-2. **Płatności** – podłącz wybrany procesor (np. Stripe) i aktualizuj `user_metadata.subscriptionPlan` po zmianie planu.
-3. **Uprawnienia RLS** – na podstawie pola `role` zdefiniuj polityki bezpieczeństwa w tabelach Supabase.
+1. **Płatności** – podłącz wybrany procesor (np. Stripe) i aktualizuj `user_metadata.subscriptionPlan` po zmianie planu.
+2. **Uprawnienia RLS** – na podstawie pola `role` zdefiniuj polityki bezpieczeństwa w tabelach Supabase.
+3. **Powiadomienia e-mail/SMS** – rozbuduj proces wysyłki zaproszeń o dodatkowe powiadomienia (np. Resend, Twilio) przy zmianach statusu zleceń.
 
 Dokumentacja Supabase: https://supabase.com/docs
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "5.10.0",
+        "@supabase/ssr": "0.5.0",
+        "@supabase/supabase-js": "2.48.1",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -959,6 +962,37 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.10.0.tgz",
+      "integrity": "sha512-JQqKYpKplsAaPDk0RVKBsN4ly6AWJys6Hkjh9PJMgtdY0IME1C0aHckyGUhHpenmOO2J6liPDDm1svSrzce8BQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -972,6 +1006,95 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.67.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
+      "integrity": "sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.18.1.tgz",
+      "integrity": "sha512-dWDnoC0MoDHKhaEOrsEKTadWQcBNknZVQcSgNE/Q2wXh05mhCL1ut/jthRUrSbYcqIw/CEjhaeIPp7dLarT0bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.5.0.tgz",
+      "integrity": "sha512-5E0NmPpfXBzfATgYhg7o/nPkVu+38mx7pO5vlhxnk/5sYGnIZcpMHJs3jONb7Jx5IJN2kTPb59luEw66MOOTaA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.6.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.9.5"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.48.1.tgz",
+      "integrity": "sha512-VMD+CYk/KxfwGbI4fqwSUVA7CLr1izXpqfFerhnYPSi6LEKD8GoR4kuO5Cc8a+N43LnfSQwLJu4kVm2e4etEmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.67.3",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.18.1",
+        "@supabase/realtime-js": "2.11.2",
+        "@supabase/storage-js": "2.7.1"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1294,11 +1417,16 @@
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.13",
@@ -1318,6 +1446,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2333,6 +2470,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5740,6 +5886,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5900,7 +6052,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -5946,6 +6097,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6061,6 +6228,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@prisma/client": "5.10.0",
+    "@supabase/ssr": "0.5.0",
+    "@supabase/supabase-js": "2.48.1",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,10 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "5.10.0"
+  },
+  "prisma": {
+    "schema": "../prisma/schema.prisma"
   }
 }

--- a/web/src/app/(auth)/login/actions.ts
+++ b/web/src/app/(auth)/login/actions.ts
@@ -1,0 +1,181 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { createSupabaseServerActionClient } from '@/lib/supabase/server';
+import {
+  CarpenterSubscriptionPlan,
+  ClientSubscriptionPlan,
+  UserRole,
+} from '@/lib/domain';
+
+type FormState = {
+  status: 'idle' | 'error' | 'success';
+  message?: string;
+};
+
+const INITIAL_STATE: FormState = { status: 'idle' };
+
+function resolveUnexpectedErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message.includes('Brak wymaganej zmiennej środowiskowej')) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function normalizeString(value: FormDataEntryValue | null): string {
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+  return '';
+}
+
+function resolveCarpenterMetadata() {
+  const affiliateCode = generateAffiliateCode();
+  return {
+    role: UserRole.CARPENTER,
+    subscriptionPlan: CarpenterSubscriptionPlan.PROFESSIONAL,
+    affiliateCode,
+  } satisfies Record<string, unknown>;
+}
+
+function generateAffiliateCode() {
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const buffer = new Uint8Array(4);
+    crypto.getRandomValues(buffer);
+    return Array.from(buffer, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  // Fallback for environments without Web Crypto (should not happen in Next.js runtimes)
+  return Math.random().toString(16).slice(2, 10).padEnd(8, '0');
+}
+
+function resolveClientMetadata(plan: ClientSubscriptionPlan, invitedBy?: string | null) {
+  const baseMetadata = {
+    role: UserRole.CLIENT,
+    subscriptionPlan: plan,
+    projectLimit: plan === ClientSubscriptionPlan.FREE ? 2 : null,
+  } satisfies Record<string, unknown>;
+
+  if (invitedBy) {
+    return { ...baseMetadata, invitedBy };
+  }
+  return baseMetadata;
+}
+
+export async function signInAction(_: FormState, formData: FormData): Promise<FormState> {
+  const email = normalizeString(formData.get('email'));
+  const password = normalizeString(formData.get('password'));
+
+  if (!email || !password) {
+    return { status: 'error', message: 'Podaj adres e-mail i hasło.' };
+  }
+
+  try {
+    const supabase = await createSupabaseServerActionClient();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+    if (error) {
+      return {
+        status: 'error',
+        message:
+          error.message === 'Invalid login credentials'
+            ? 'Niepoprawny e-mail lub hasło.'
+            : `Nie udało się zalogować: ${error.message}`,
+      };
+    }
+
+    redirect('/');
+    return INITIAL_STATE;
+  } catch (error) {
+    console.error('Nie udało się zalogować użytkownika.', error);
+    return {
+      status: 'error',
+      message: resolveUnexpectedErrorMessage(
+        error,
+        'Wystąpił błąd serwera podczas logowania. Spróbuj ponownie później.',
+      ),
+    };
+  }
+}
+
+export async function signUpAction(_: FormState, formData: FormData): Promise<FormState> {
+  const email = normalizeString(formData.get('email'));
+  const password = normalizeString(formData.get('password'));
+  const role = normalizeString(formData.get('role'));
+  const clientPlan = normalizeString(formData.get('clientPlan'));
+  const invitedBy = normalizeString(formData.get('invitedBy')) || undefined;
+
+  if (!email || !password) {
+    return { status: 'error', message: 'Podaj adres e-mail oraz hasło.' };
+  }
+
+  if (password.length < 8) {
+    return { status: 'error', message: 'Hasło musi mieć co najmniej 8 znaków.' };
+  }
+
+  if (role !== UserRole.CARPENTER && role !== UserRole.CLIENT) {
+    return { status: 'error', message: 'Wybierz typ konta.' };
+  }
+
+  try {
+    const supabase = await createSupabaseServerActionClient();
+
+    const metadata =
+      role === UserRole.CARPENTER
+        ? resolveCarpenterMetadata()
+        : resolveClientMetadata(
+            clientPlan === ClientSubscriptionPlan.PREMIUM
+              ? ClientSubscriptionPlan.PREMIUM
+              : ClientSubscriptionPlan.FREE,
+            invitedBy,
+          );
+
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'}/auth/callback`,
+        data: metadata,
+      },
+    });
+
+    if (error) {
+      return {
+        status: 'error',
+        message: error.message.includes('already registered')
+          ? 'Adres e-mail jest już zajęty. Zaloguj się zamiast tego.'
+          : `Nie udało się utworzyć konta: ${error.message}`,
+      };
+    }
+
+    if (data.session) {
+      redirect('/');
+    }
+
+    return {
+      status: 'success',
+      message: 'Sprawdź skrzynkę e-mail i potwierdź rejestrację, aby się zalogować.',
+    };
+  } catch (error) {
+    console.error('Nie udało się utworzyć konta użytkownika.', error);
+    return {
+      status: 'error',
+      message: resolveUnexpectedErrorMessage(
+        error,
+        'Wystąpił błąd serwera podczas rejestracji. Spróbuj ponownie później.',
+      ),
+    };
+  }
+}
+
+export async function signOutAction() {
+  try {
+    const supabase = await createSupabaseServerActionClient();
+    await supabase.auth.signOut();
+  } catch (error) {
+    console.error('Nie udało się wylogować użytkownika.', error);
+  }
+  redirect('/login');
+}
+
+export { INITIAL_STATE };

--- a/web/src/app/(auth)/login/actions.ts
+++ b/web/src/app/(auth)/login/actions.ts
@@ -136,3 +136,4 @@ export async function signOutAction() {
   redirect('/login');
 }
 
+export { INITIAL_STATE };

--- a/web/src/app/(auth)/login/auth-forms.tsx
+++ b/web/src/app/(auth)/login/auth-forms.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo, useState } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
-import { INITIAL_STATE, signInAction, signUpAction } from './actions';
+import { signInAction, signUpAction } from './actions';
+import { INITIAL_STATE } from './state';
 import { ClientSubscriptionPlan, UserRole } from '@/lib/domain';
 
 type AuthFormsProps = {

--- a/web/src/app/(auth)/login/auth-forms.tsx
+++ b/web/src/app/(auth)/login/auth-forms.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+import { INITIAL_STATE, signInAction, signUpAction } from './actions';
+import { ClientSubscriptionPlan, UserRole } from '@/lib/domain';
+
+type AuthFormsProps = {
+  invitedBy?: string | null;
+};
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="w-full rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={pending}
+    >
+      {pending ? 'Przetwarzanie…' : label}
+    </button>
+  );
+}
+
+function ErrorMessage({ state }: { state: { status: string; message?: string } }) {
+  if (state.status !== 'error' || !state.message) {
+    return null;
+  }
+
+  return (
+    <p className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+      {state.message}
+    </p>
+  );
+}
+
+function SuccessMessage({ state }: { state: { status: string; message?: string } }) {
+  if (state.status !== 'success' || !state.message) {
+    return null;
+  }
+
+  return (
+    <p className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+      {state.message}
+    </p>
+  );
+}
+
+export function AuthForms({ invitedBy }: AuthFormsProps) {
+  const [mode, setMode] = useState<'login' | 'register'>(invitedBy ? 'register' : 'login');
+  const [loginState, loginAction] = useFormState(signInAction, INITIAL_STATE);
+  const [registerState, registerAction] = useFormState(signUpAction, INITIAL_STATE);
+
+  const invitationNotice = useMemo(() => {
+    if (!invitedBy) {
+      return null;
+    }
+    return (
+      <p className="rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-3 text-xs text-emerald-200">
+        Zostałeś zaproszony do współpracy przez stolarza o identyfikatorze <span className="font-semibold">{invitedBy}</span>.
+        Po rejestracji Twoje konto zostanie automatycznie powiązane z jego warsztatem.
+      </p>
+    );
+  }, [invitedBy]);
+
+  return (
+    <div className="mx-auto w-full max-w-xl rounded-3xl border border-white/10 bg-slate-950/80 p-8 shadow-xl shadow-black/40">
+      <div className="mb-6 flex items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => setMode('login')}
+          className={`flex-1 rounded-full px-4 py-2 text-sm font-semibold transition ${
+            mode === 'login'
+              ? 'bg-emerald-500 text-emerald-950'
+              : 'bg-white/5 text-slate-300 hover:bg-white/10 hover:text-white'
+          }`}
+        >
+          Mam konto
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('register')}
+          className={`flex-1 rounded-full px-4 py-2 text-sm font-semibold transition ${
+            mode === 'register'
+              ? 'bg-emerald-500 text-emerald-950'
+              : 'bg-white/5 text-slate-300 hover:bg-white/10 hover:text-white'
+          }`}
+        >
+          Chcę dołączyć
+        </button>
+      </div>
+
+      {mode === 'login' ? (
+        <form className="space-y-4" action={loginAction}>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              E-mail
+            </label>
+            <input
+              name="email"
+              type="email"
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Hasło
+            </label>
+            <input
+              name="password"
+              type="password"
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+          </div>
+          <ErrorMessage state={loginState} />
+          <SubmitButton label="Zaloguj się" />
+        </form>
+      ) : (
+        <form className="space-y-4" action={registerAction}>
+          <input type="hidden" name="invitedBy" value={invitedBy ?? ''} />
+          {invitationNotice}
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Adres e-mail
+            </label>
+            <input
+              name="email"
+              type="email"
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Hasło
+            </label>
+            <input
+              name="password"
+              type="password"
+              minLength={8}
+              required
+              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+            />
+            <p className="mt-1 text-xs text-slate-400">Minimum 8 znaków, zalecane litery i cyfry.</p>
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              Typ konta
+            </label>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <label className="flex cursor-pointer flex-col rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-emerald-500/40">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Stolarz</span>
+                  <input
+                    type="radio"
+                    name="role"
+                    value={UserRole.CARPENTER}
+                    className="h-4 w-4"
+                    required
+                  />
+                </div>
+                <p className="mt-2 text-xs text-slate-300">
+                  Pełny dostęp do tworzenia projektów, wycen i panelu warsztatu. Wymagana aktywna subskrypcja.
+                </p>
+              </label>
+              <label className="flex cursor-pointer flex-col rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:border-emerald-500/40">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-white">Klient</span>
+                  <input
+                    type="radio"
+                    name="role"
+                    value={UserRole.CLIENT}
+                    className="h-4 w-4"
+                    required
+                  />
+                </div>
+                <p className="mt-2 text-xs text-slate-300">
+                  Darmowe konto do wysyłania zapytań ofertowych do maksymalnie 2 stolarzy.
+                </p>
+                <div className="mt-4 space-y-2 rounded-xl bg-slate-900/60 p-3">
+                  <label className="flex items-center justify-between text-xs text-slate-200">
+                    <span>Plan standardowy</span>
+                    <input
+                      type="radio"
+                      name="clientPlan"
+                      value={ClientSubscriptionPlan.FREE}
+                      defaultChecked
+                      className="h-3 w-3"
+                    />
+                  </label>
+                  <label className="flex items-center justify-between text-xs text-slate-200">
+                    <span>Plan premium (nielimitowane zapytania)</span>
+                    <input
+                      type="radio"
+                      name="clientPlan"
+                      value={ClientSubscriptionPlan.PREMIUM}
+                      className="h-3 w-3"
+                    />
+                  </label>
+                </div>
+              </label>
+            </div>
+          </div>
+          <ErrorMessage state={registerState} />
+          <SuccessMessage state={registerState} />
+          <SubmitButton label="Utwórz konto" />
+        </form>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { AuthForms } from './auth-forms';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export const metadata: Metadata = {
+  title: 'Meblomat – Logowanie i rejestracja',
+  description:
+    'Zaloguj się lub dołącz do platformy Meblomat jako stolarz lub klient. Konta integrowane z Supabase.',
+};
+
+type LoginPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const cookieStore = await cookies();
+  const supabase = createSupabaseServerClient(cookieStore);
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session) {
+    redirect('/');
+  }
+
+  const params = (await searchParams) ?? {};
+  const refParam = Array.isArray(params.ref) ? params.ref[0] : params.ref;
+  const invitedParam = Array.isArray(params.invitedBy) ? params.invitedBy[0] : params.invitedBy;
+  const invitedBy = refParam ?? invitedParam ?? null;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 px-6 py-16 text-slate-100">
+      <div className="mb-8 text-center">
+        <span className="inline-flex rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+          Meblomat
+        </span>
+        <h1 className="mt-4 text-3xl font-semibold text-white md:text-4xl">Witaj w panelu warsztatu</h1>
+        <p className="mt-2 max-w-xl text-sm text-slate-300">
+          Zaloguj się, aby zarządzać warsztatem stolarskim, lub utwórz konto klienta i wysyłaj swoje projekty do wyceny.
+        </p>
+      </div>
+      <AuthForms invitedBy={invitedBy} />
+    </main>
+  );
+}

--- a/web/src/app/(auth)/login/state.ts
+++ b/web/src/app/(auth)/login/state.ts
@@ -1,0 +1,6 @@
+export type FormState = {
+  status: 'idle' | 'error' | 'success';
+  message?: string;
+};
+
+export const INITIAL_STATE: FormState = { status: 'idle' };

--- a/web/src/app/actions/send-client-invite.ts
+++ b/web/src/app/actions/send-client-invite.ts
@@ -1,0 +1,97 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { ClientSubscriptionPlan, UserRole } from '@/lib/domain';
+import { resolveClientMetadata } from '@/lib/auth/metadata';
+import { createSupabaseAdminClient, SERVICE_ROLE_ERROR_MESSAGE } from '@/lib/supabase/admin';
+import { getSiteUrl } from '@/lib/supabase/config';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export type InviteFormState = {
+  status: 'idle' | 'error' | 'success';
+  message?: string;
+};
+
+export const INVITE_INITIAL_STATE: InviteFormState = { status: 'idle' };
+
+function normalizeString(value: FormDataEntryValue | null) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function resolveUnexpectedErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message === SERVICE_ROLE_ERROR_MESSAGE) {
+    return error.message;
+  }
+  return fallback;
+}
+
+export async function sendClientInviteAction(
+  _: InviteFormState,
+  formData: FormData,
+): Promise<InviteFormState> {
+  const email = normalizeString(formData.get('email'));
+  const planValue = normalizeString(formData.get('plan'));
+
+  if (!email) {
+    return { status: 'error', message: 'Podaj adres e-mail klienta.' };
+  }
+
+  const plan =
+    planValue === ClientSubscriptionPlan.PREMIUM
+      ? ClientSubscriptionPlan.PREMIUM
+      : ClientSubscriptionPlan.FREE;
+
+  try {
+    const cookieStore = await cookies();
+    const supabase = createSupabaseServerClient(cookieStore);
+    const {
+      data: { session },
+      error: sessionError,
+    } = await supabase.auth.getSession();
+
+    if (sessionError) {
+      throw sessionError;
+    }
+
+    if (!session) {
+      return { status: 'error', message: 'Aby wysłać zaproszenie, zaloguj się na konto stolarza.' };
+    }
+
+    const metadata = (session.user.user_metadata ?? {}) as Record<string, unknown>;
+    const role = metadata.role as string | undefined;
+
+    if (role !== UserRole.CARPENTER) {
+      return { status: 'error', message: 'Tylko stolarze mogą zapraszać klientów do warsztatu.' };
+    }
+
+    const admin = createSupabaseAdminClient();
+    const siteUrl = getSiteUrl().replace(/\/$/, '');
+    const { error } = await admin.auth.admin.inviteUserByEmail(email, {
+      data: resolveClientMetadata(plan, session.user.id),
+      redirectTo: `${siteUrl}/auth/callback`,
+    });
+
+    if (error) {
+      return {
+        status: 'error',
+        message: error.message.includes('already registered')
+          ? 'Ten adres e-mail jest już używany w Supabase. Poproś klienta o zalogowanie się.'
+          : `Nie udało się wysłać zaproszenia: ${error.message}`,
+      };
+    }
+
+    return {
+      status: 'success',
+      message: `Zaproszenie zostało wysłane do ${email}.`,
+    };
+  } catch (error) {
+    console.error('Nie udało się wysłać zaproszenia klientowi.', error);
+    return {
+      status: 'error',
+      message: resolveUnexpectedErrorMessage(
+        error,
+        'Wystąpił błąd podczas wysyłania zaproszenia. Sprawdź konfigurację i spróbuj ponownie.',
+      ),
+    };
+  }
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { DatabaseStatusCard } from '@/components/database-status-card';
 import { CopyField } from '@/components/copy-field';
+import { InviteClientForm } from '@/components/invite-client-form';
 import { OrderPriorityBadge, OrderStatusBadge } from '@/components/order-status-pill';
 import { OrdersPipeline } from '@/components/orders-pipeline';
 import { SignOutButton } from '@/components/sign-out-button';
@@ -65,6 +66,7 @@ export default async function Home() {
 
   const siteUrl = getSiteUrl().replace(/\/$/, '');
   const affiliateLink = `${siteUrl}/login?ref=${affiliateCode ?? session.user.id}`;
+  const serviceRoleConfigured = Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY);
 
   const roleLabel =
     userRole === UserRole.ADMIN
@@ -157,13 +159,23 @@ export default async function Home() {
             <div className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow shadow-black/30">
               <h3 className="text-base font-semibold text-white">Zaproszenia e-mail</h3>
               <p className="mt-2 text-sm text-slate-300">
-                Wysyłaj spersonalizowane zaproszenia klientom bezpośrednio z panelu po skonfigurowaniu funkcji serwerowej z kluczem
-                <code className="mx-1 rounded bg-slate-950/80 px-1">SUPABASE_SERVICE_ROLE_KEY</code>.
+                Wprowadź adres e-mail klienta, aby Supabase wysłało do niego zaproszenie z linkiem aktywacyjnym.
               </p>
-              <p className="mt-3 text-xs text-slate-400">
-                Dodaj integrację z dostawcą e-mail (np. Resend) i użyj Supabase Admin API, aby automatycznie tworzyć konta klientów i wysyłać im link do
-                rejestracji.
-              </p>
+              {serviceRoleConfigured ? (
+                <>
+                  <p className="mt-3 text-xs text-slate-400">
+                    Zaproszone osoby otrzymają konto klienta powiązane automatycznie z Twoim warsztatem. Możesz od razu wybrać ich plan.
+                  </p>
+                  <div className="mt-4">
+                    <InviteClientForm />
+                  </div>
+                </>
+              ) : (
+                <p className="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-200">
+                  Skonfiguruj zmienną <code className="rounded bg-slate-950/70 px-1">SUPABASE_SERVICE_ROLE_KEY</code>, aby aktywować wysyłkę zaproszeń z panelu.
+                  Klucz znajdziesz w ustawieniach swojego projektu Supabase.
+                </p>
+              )}
             </div>
           </section>
         ) : null}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -169,6 +169,9 @@ export default async function Home() {
                   <div className="mt-4">
                     <InviteClientForm />
                   </div>
+                  <p className="mt-3 text-xs text-slate-400">
+                    Połącz funkcję z dostawcą e-mail (np. Resend), aby wysyłać spersonalizowane wiadomości z Supabase Admin API.
+                  </p>
                 </>
               ) : (
                 <p className="mt-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-200">

--- a/web/src/components/copy-field.tsx
+++ b/web/src/components/copy-field.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+
+type CopyFieldProps = {
+  label: string;
+  value: string;
+};
+
+export function CopyField({ label, value }: CopyFieldProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy link', error);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      <code className="flex-1 truncate rounded-xl border border-white/10 bg-slate-950/60 px-4 py-2 text-sm text-slate-200">
+        {value}
+      </code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-100 transition hover:bg-emerald-500/20"
+      >
+        {copied ? 'Skopiowano!' : label}
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/invite-client-form.tsx
+++ b/web/src/components/invite-client-form.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+import { INVITE_INITIAL_STATE, sendClientInviteAction } from '@/app/actions/send-client-invite';
+import { ClientSubscriptionPlan } from '@/lib/domain';
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="w-full rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={pending}
+    >
+      {pending ? 'Wysyłanie…' : 'Wyślij zaproszenie'}
+    </button>
+  );
+}
+
+export function InviteClientForm() {
+  const [state, formAction] = useFormState(sendClientInviteAction, INVITE_INITIAL_STATE);
+
+  const alert = useMemo(() => {
+    if (state.status === 'idle') {
+      return null;
+    }
+
+    const className =
+      state.status === 'success'
+        ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+        : 'border-red-500/40 bg-red-500/10 text-red-200';
+
+    return (
+      <p className={`rounded-lg border p-3 text-sm ${className}`}>
+        {state.message}
+      </p>
+    );
+  }, [state]);
+
+  return (
+    <form className="space-y-4" action={formAction}>
+      <div>
+        <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+          E-mail klienta
+        </label>
+        <input
+          name="email"
+          type="email"
+          required
+          className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white outline-none focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/40"
+          placeholder="klient@przyklad.pl"
+        />
+      </div>
+      <div>
+        <label className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+          Plan klienta
+        </label>
+        <div className="mt-3 space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-slate-200">
+          <label className="flex items-center justify-between">
+            <span>Standard (limit 2 zapytań jednocześnie)</span>
+            <input type="radio" name="plan" value={ClientSubscriptionPlan.FREE} defaultChecked className="h-3 w-3" />
+          </label>
+          <label className="flex items-center justify-between">
+            <span>Premium (brak limitów wysyłki)</span>
+            <input type="radio" name="plan" value={ClientSubscriptionPlan.PREMIUM} className="h-3 w-3" />
+          </label>
+        </div>
+      </div>
+      {alert}
+      <SubmitButton />
+    </form>
+  );
+}

--- a/web/src/components/sign-out-button.tsx
+++ b/web/src/components/sign-out-button.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+import { signOutAction } from '@/app/(auth)/login/actions';
+
+function SignOutSubmit() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-red-400/40 hover:bg-red-500/10 hover:text-red-100 disabled:opacity-60"
+      disabled={pending}
+    >
+      {pending ? 'Wylogowywanie…' : 'Wyloguj'}
+    </button>
+  );
+}
+
+export function SignOutButton() {
+  return (
+    <form action={signOutAction} className="inline-flex">
+      <SignOutSubmit />
+    </form>
+  );
+}

--- a/web/src/lib/auth/metadata.ts
+++ b/web/src/lib/auth/metadata.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { CarpenterSubscriptionPlan, ClientSubscriptionPlan, UserRole } from '@/lib/domain';
 
 function generateAffiliateCode() {
@@ -7,7 +8,15 @@ function generateAffiliateCode() {
     return Array.from(buffer, (byte) => byte.toString(16).padStart(2, '0')).join('');
   }
 
-  // Fallback for environments without Web Crypto (should not happen in Next.js runtimes)
+  try {
+    return randomBytes(4).toString('hex');
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('Nie udało się wygenerować kodu afiliacyjnego z użyciem crypto.randomBytes.', error);
+    }
+  }
+
+  // Ostateczne zabezpieczenie – deterministyczne dla środowisk pozbawionych API crypto.
   return Math.random().toString(16).slice(2, 10).padEnd(8, '0');
 }
 

--- a/web/src/lib/auth/metadata.ts
+++ b/web/src/lib/auth/metadata.ts
@@ -1,0 +1,34 @@
+import { CarpenterSubscriptionPlan, ClientSubscriptionPlan, UserRole } from '@/lib/domain';
+
+function generateAffiliateCode() {
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const buffer = new Uint8Array(4);
+    crypto.getRandomValues(buffer);
+    return Array.from(buffer, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  // Fallback for environments without Web Crypto (should not happen in Next.js runtimes)
+  return Math.random().toString(16).slice(2, 10).padEnd(8, '0');
+}
+
+export function resolveCarpenterMetadata() {
+  const affiliateCode = generateAffiliateCode();
+  return {
+    role: UserRole.CARPENTER,
+    subscriptionPlan: CarpenterSubscriptionPlan.PROFESSIONAL,
+    affiliateCode,
+  } satisfies Record<string, unknown>;
+}
+
+export function resolveClientMetadata(plan: ClientSubscriptionPlan, invitedBy?: string | null) {
+  const baseMetadata = {
+    role: UserRole.CLIENT,
+    subscriptionPlan: plan,
+    projectLimit: plan === ClientSubscriptionPlan.FREE ? 2 : null,
+  } satisfies Record<string, unknown>;
+
+  if (invitedBy) {
+    return { ...baseMetadata, invitedBy };
+  }
+  return baseMetadata;
+}

--- a/web/src/lib/domain.ts
+++ b/web/src/lib/domain.ts
@@ -28,3 +28,26 @@ export const TaskStatus = Object.freeze({
 
 export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 export const TASK_STATUSES = Object.values(TaskStatus) as TaskStatus[];
+
+export const UserRole = Object.freeze({
+  ADMIN: 'admin',
+  CARPENTER: 'carpenter',
+  CLIENT: 'client',
+} as const);
+
+export type UserRole = (typeof UserRole)[keyof typeof UserRole];
+
+export const ClientSubscriptionPlan = Object.freeze({
+  FREE: 'client_free',
+  PREMIUM: 'client_premium',
+} as const);
+
+export type ClientSubscriptionPlan =
+  (typeof ClientSubscriptionPlan)[keyof typeof ClientSubscriptionPlan];
+
+export const CarpenterSubscriptionPlan = Object.freeze({
+  PROFESSIONAL: 'carpenter_professional',
+} as const);
+
+export type CarpenterSubscriptionPlan =
+  (typeof CarpenterSubscriptionPlan)[keyof typeof CarpenterSubscriptionPlan];

--- a/web/src/lib/supabase/admin.ts
+++ b/web/src/lib/supabase/admin.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL } from './config';
+
+const SERVICE_ROLE_ERROR_MESSAGE =
+  'Skonfiguruj zmienną SUPABASE_SERVICE_ROLE_KEY, aby wysyłać zaproszenia z poziomu panelu.';
+
+export function assertServiceRoleKey(): asserts SUPABASE_SERVICE_ROLE_KEY {
+  if (!SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(SERVICE_ROLE_ERROR_MESSAGE);
+  }
+}
+
+export function createSupabaseAdminClient(): SupabaseClient {
+  assertServiceRoleKey();
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+export { SERVICE_ROLE_ERROR_MESSAGE };

--- a/web/src/lib/supabase/admin.ts
+++ b/web/src/lib/supabase/admin.ts
@@ -5,15 +5,16 @@ import { SUPABASE_SERVICE_ROLE_KEY, SUPABASE_URL } from './config';
 const SERVICE_ROLE_ERROR_MESSAGE =
   'Skonfiguruj zmienną SUPABASE_SERVICE_ROLE_KEY, aby wysyłać zaproszenia z poziomu panelu.';
 
-export function assertServiceRoleKey(): asserts SUPABASE_SERVICE_ROLE_KEY {
-  if (!SUPABASE_SERVICE_ROLE_KEY) {
+export function assertServiceRoleKey(value: string | undefined): asserts value is string {
+  if (!value) {
     throw new Error(SERVICE_ROLE_ERROR_MESSAGE);
   }
 }
 
 export function createSupabaseAdminClient(): SupabaseClient {
-  assertServiceRoleKey();
-  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  const serviceRoleKey = SUPABASE_SERVICE_ROLE_KEY;
+  assertServiceRoleKey(serviceRoleKey);
+  return createClient(SUPABASE_URL, serviceRoleKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/web/src/lib/supabase/client.ts
+++ b/web/src/lib/supabase/client.ts
@@ -1,0 +1,12 @@
+import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
+
+let browserClient: SupabaseClient | undefined;
+
+export function getSupabaseBrowserClient(): SupabaseClient {
+  if (!browserClient) {
+    browserClient = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  }
+  return browserClient;
+}

--- a/web/src/lib/supabase/config.ts
+++ b/web/src/lib/supabase/config.ts
@@ -1,0 +1,17 @@
+function readEnv(name: string) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Brak wymaganej zmiennej środowiskowej ${name}. Uzupełnij konfigurację Supabase w pliku .env.local.`,
+    );
+  }
+  return value;
+}
+
+export const SUPABASE_URL = readEnv('NEXT_PUBLIC_SUPABASE_URL');
+export const SUPABASE_ANON_KEY = readEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+export function getSiteUrl() {
+  return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+}

--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -1,0 +1,37 @@
+import { cookies } from 'next/headers';
+import type { CookieOptions } from '@supabase/ssr';
+import { createServerClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
+
+type CookieStore = Awaited<ReturnType<typeof cookies>>;
+type CookieAccessor = () => CookieStore;
+
+function createCookieAdapter(accessCookies: CookieAccessor) {
+  return {
+    get(name: string) {
+      return accessCookies().get(name)?.value;
+    },
+    set(name: string, value: string, options: CookieOptions) {
+      accessCookies().set({ name, value, ...options });
+    },
+    remove(name: string, options: CookieOptions) {
+      accessCookies().set({ name, value: '', ...options, expires: new Date(0) });
+    },
+  };
+}
+
+function createSupabaseClient(accessCookies: CookieAccessor): SupabaseClient {
+  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: createCookieAdapter(accessCookies),
+  });
+}
+
+export function createSupabaseServerClient(cookieStore: CookieStore): SupabaseClient {
+  return createSupabaseClient(() => cookieStore);
+}
+
+export async function createSupabaseServerActionClient(): Promise<SupabaseClient> {
+  const cookieStore = await cookies();
+  return createSupabaseClient(() => cookieStore);
+}


### PR DESCRIPTION
## Summary
- add a dedicated Supabase server action client that works with Next.js cookies accessors
- wrap sign-in, sign-up, and sign-out actions with error handling and clearer fallback messages
- generate carpenter affiliate codes with Web Crypto to keep auth flows edge-compatible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55dc515248322a4756e05454e17da