### PR TITLE
Use direct Supabase URL for Prisma

### DIFF
--- a/.env
+++ b/.env
@@ -1,36 +1,8 @@
-# Example environment variables file for the carpentry system.
+# Environment configuration for the carpentry system.
 #
-# Copy this file to .env and replace the placeholder values with your actual
-# Supabase (lub Cloud SQL) connection details.  Do not commit real credentials
-# to the repository.
-#
-# 1) Połączenie przez PgBouncer (port 6543) – zalecane dla środowisk
-#    serverless. Parametry `pgbouncer=true` i `connection_limit=1` ograniczają
-#    liczbę połączeń Prisma.
-#
+# Prisma expects DATABASE_URL to point to the Supabase instance.  We default to
+# the direct connection (port 5432) so schema migrations run without PgBouncer
+# limitations.  For short-lived, pooled connections, use DATABASE_URL_POOLED.
 
-DATABASE_URL="postgresql://postgres.bxfsfzazajspbogfpdtw:rolowanieuda6x6QAZ@aws-1-eu-north-1.pooler.supabase.com:6543/postgres?sslmode=require&pgbouncer=true&connection_limit=1&connect_timeout=15"
-DATABASE_URL_UNPOOLED="postgresql://postgres.bxfsfzazajspbogfpdtw:rolowanieuda6x6QAZ@db.bxfsfzazajspbogfpdtw.supabase.co:5432/postgres?sslmode=require"
-=======
-
-DATABASE_URL="postgresql://postgres:rolowanieuda6x6QAZ@aws-1-eu-north-1.pooler.supabase.com:6543/postgres?sslmode=require&pgbouncer=true&connection_limit=1&connect_timeout=15"
-# DATABASE_URL="postgresql://postgres.bxfsfzazajspbogfpdtw:rolowanieuda6x6QAZ@aws-1-eu-north-1.pooler.supabase.com:6543/postgres"
-=======
-# DATABASE_URL="postgres://postgres:rolowanieuda6x6QAZ@aws-1-eu-north-1.pooler.supabase.com:6543/postgres?sslmode=require&pgbouncer=true&connection_limit=1&connect_timeout=15"
- # DATABASE_URL=postgresql://postgres.bxfsfzazajspbogfpdtw:rolowanieuda6x6QAZ@aws-1-eu-north-1.pooler.supabase.com:6543/postgres
-
-
-# 2) Połączenie bezpośrednie (port 5432) – wygodne lokalnie, ale mniej
-#    odporne na limity połączeń.  W razie potrzeby odkomentuj poniższą
-#    linię i przypisz ją do `DATABASE_URL`, by wymusić połączenie bez
-#    PgBouncera.
-#
-
-# DATABASE_URL=$DATABASE_URL_UNPOOLED
-=======
-# DATABASE_URL="postgresql://postgres:rolowanieuda6x6@db.bxfsfzazajspbogfpdtw.supabase.co:5432/postgres?sslmode=require"
-# DATABASE_URL="postgresql://postgres:rolowanieuda6x6QAZ@db.bxfsfzazajspbogfpdtw.supabase.co:5432/postgres"
-
-#
-# Po skopiowaniu usuń znak # przed wybraną opcją i uzupełnij własnymi danymi.
-#  DATABASE_URL=https://bxfsfzazajspbogfpdtw.supabase.co
+DATABASE_URL="postgresql://postgres:rolowanieuda6x6QAZ@db.bxfsfzazajspbogfpdtw.supabase.co:5432/postgres?sslmode=require"
+DATABASE_URL_POOLED="postgresql://postgres.bxfsfzazajspbogfpdtw:rolowanieuda6x6QAZ@aws-1-eu-north-1.pooler.supabase.com:6543/postgres?sslmode=require&pgbouncer=true&connection_limit=1&connect_timeout=15"


### PR DESCRIPTION
## Summary
- point DATABASE_URL at the direct Supabase connection so Prisma migrations authenticate successfully
- keep the pooled PgBouncer connection as DATABASE_URL_POOLED for short-lived workloads

## Testing
- not run (Prisma CLI prompts for a newer global install)

------
https://chatgpt.com/codex/tasks/task_e_68d5a648be68832283652dbb9056f73b