### PR TITLE
Fix redirect handling in auth actions

### DIFF
--- a/web/src/app/(auth)/login/actions.ts
+++ b/web/src/app/(auth)/login/actions.ts
@@ -3,6 +3,7 @@
 import { randomBytes } from 'crypto';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { isRedirectError } from 'next/dist/client/components/redirect-error';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import {
   CarpenterSubscriptionPlan,
@@ -47,89 +48,116 @@ function resolveClientMetadata(plan: ClientSubscriptionPlan, invitedBy?: string 
 }
 
 export async function signInAction(_: FormState, formData: FormData): Promise<FormState> {
-  const email = normalizeString(formData.get('email'));
-  const password = normalizeString(formData.get('password'));
+  try {
+    const email = normalizeString(formData.get('email'));
+    const password = normalizeString(formData.get('password'));
 
-  if (!email || !password) {
-    return { status: 'error', message: 'Podaj adres e-mail i hasło.' };
-  }
+    if (!email || !password) {
+      return { status: 'error', message: 'Podaj adres e-mail i hasło.' };
+    }
 
-  const cookieStore = await cookies();
-  const supabase = createSupabaseServerClient(cookieStore);
-  const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const cookieStore = await cookies();
+    const supabase = createSupabaseServerClient(cookieStore);
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
 
-  if (error) {
+    if (error) {
+      return {
+        status: 'error',
+        message:
+          error.message === 'Invalid login credentials'
+            ? 'Niepoprawny e-mail lub hasło.'
+            : `Nie udało się zalogować: ${error.message}`,
+      };
+    }
+
+    redirect('/');
+    return INITIAL_STATE;
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    }
+
+    console.error('Unexpected error during sign in:', error);
     return {
       status: 'error',
-      message:
-        error.message === 'Invalid login credentials'
-          ? 'Niepoprawny e-mail lub hasło.'
-          : `Nie udało się zalogować: ${error.message}`,
+      message: 'Wystąpił nieoczekiwany błąd podczas logowania. Spróbuj ponownie.',
     };
   }
-
-  redirect('/');
-  return INITIAL_STATE;
 }
 
 export async function signUpAction(_: FormState, formData: FormData): Promise<FormState> {
-  const email = normalizeString(formData.get('email'));
-  const password = normalizeString(formData.get('password'));
-  const role = normalizeString(formData.get('role'));
-  const clientPlan = normalizeString(formData.get('clientPlan'));
-  const invitedBy = normalizeString(formData.get('invitedBy')) || undefined;
+  try {
+    const email = normalizeString(formData.get('email'));
+    const password = normalizeString(formData.get('password'));
+    const role = normalizeString(formData.get('role'));
+    const clientPlan = normalizeString(formData.get('clientPlan'));
+    const invitedBy = normalizeString(formData.get('invitedBy')) || undefined;
 
-  if (!email || !password) {
-    return { status: 'error', message: 'Podaj adres e-mail oraz hasło.' };
-  }
+    if (!email || !password) {
+      return { status: 'error', message: 'Podaj adres e-mail oraz hasło.' };
+    }
 
-  if (password.length < 8) {
-    return { status: 'error', message: 'Hasło musi mieć co najmniej 8 znaków.' };
-  }
+    if (password.length < 8) {
+      return { status: 'error', message: 'Hasło musi mieć co najmniej 8 znaków.' };
+    }
 
-  if (role !== UserRole.CARPENTER && role !== UserRole.CLIENT) {
-    return { status: 'error', message: 'Wybierz typ konta.' };
-  }
+    if (role !== UserRole.CARPENTER && role !== UserRole.CLIENT) {
+      return { status: 'error', message: 'Wybierz typ konta.' };
+    }
 
-  const cookieStore = await cookies();
-  const supabase = createSupabaseServerClient(cookieStore);
+    const cookieStore = await cookies();
+    const supabase = createSupabaseServerClient(cookieStore);
 
-  const metadata =
-    role === UserRole.CARPENTER
-      ? resolveCarpenterMetadata()
-      : resolveClientMetadata(
-          clientPlan === ClientSubscriptionPlan.PREMIUM
-            ? ClientSubscriptionPlan.PREMIUM
-            : ClientSubscriptionPlan.FREE,
-          invitedBy,
-        );
+    const metadata =
+      role === UserRole.CARPENTER
+        ? resolveCarpenterMetadata()
+        : resolveClientMetadata(
+            clientPlan === ClientSubscriptionPlan.PREMIUM
+              ? ClientSubscriptionPlan.PREMIUM
+              : ClientSubscriptionPlan.FREE,
+            invitedBy,
+          );
 
-  const { data, error } = await supabase.auth.signUp({
-    email,
-    password,
-    options: {
-      emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'}/auth/callback`,
-      data: metadata,
-    },
-  });
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: `${
+          process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+        }/auth/callback`,
+        data: metadata,
+      },
+    });
 
-  if (error) {
+    if (error) {
+      return {
+        status: 'error',
+        message: error.message.includes('already registered')
+          ? 'Adres e-mail jest już zajęty. Zaloguj się zamiast tego.'
+          : `Nie udało się utworzyć konta: ${error.message}`,
+      };
+    }
+
+    if (data.session) {
+      redirect('/');
+      return INITIAL_STATE;
+    }
+
+    return {
+      status: 'success',
+      message: 'Sprawdź skrzynkę e-mail i potwierdź rejestrację, aby się zalogować.',
+    };
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    }
+
+    console.error('Unexpected error during sign up:', error);
     return {
       status: 'error',
-      message: error.message.includes('already registered')
-        ? 'Adres e-mail jest już zajęty. Zaloguj się zamiast tego.'
-        : `Nie udało się utworzyć konta: ${error.message}`,
+      message: 'Wystąpił nieoczekiwany błąd podczas rejestracji. Spróbuj ponownie.',
     };
   }
-
-  if (data.session) {
-    redirect('/');
-  }
-
-  return {
-    status: 'success',
-    message: 'Sprawdź skrzynkę e-mail i potwierdź rejestrację, aby się zalogować.',
-  };
 }
 
 export async function signOutAction() {


### PR DESCRIPTION
## Summary
- rethrow Next.js redirect errors in the login and signup server actions while preserving Supabase messaging
- return the initial state after successful authentication and add fallback error responses for unexpected failures

## Testing
- npm run lint
- npm run build *(fails: missing Supabase environment configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d652f76ab08322b9d2c4502dd7581f