### PR TITLE
Handle readonly cookies error in Supabase adapter

### DIFF
--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -12,12 +12,37 @@ function createCookieAdapter(cookieStore: CookieStore) {
       return cookieStore.get(name)?.value;
     },
     set(name: string, value: string, options: CookieOptions) {
-      cookieStore.set({ name, value, ...options });
+      try {
+        cookieStore.set({ name, value, ...options });
+      } catch (error) {
+        if (!isReadonlyRequestCookiesError(error)) {
+          throw error;
+        }
+      }
     },
     remove(name: string, options: CookieOptions) {
-      cookieStore.set({ name, value: '', ...options, expires: new Date(0) });
+      try {
+        cookieStore.set({
+          name,
+          value: '',
+          ...options,
+          expires: new Date(0),
+        });
+      } catch (error) {
+        if (!isReadonlyRequestCookiesError(error)) {
+          throw error;
+        }
+      }
     },
   };
+}
+
+function isReadonlyRequestCookiesError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'ReadonlyRequestCookiesError' ||
+      error.message.includes('ReadonlyRequestCookiesError'))
+  );
 }
 
 export function createSupabaseServerClient(cookieStore: CookieStore): SupabaseClient {


### PR DESCRIPTION
## Summary
- wrap Supabase cookie mutations in guards that ignore ReadonlyRequestCookiesError when running in server components
- add a helper to detect readonly cookie errors so mutations still work in mutable cookie stores

## Testing
- NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run web:dev *(fails: Next.js throws `A "use server" file can only export async functions, found object.` from existing sign-out action exports)*

------
https://chatgpt.com/codex/tasks/task_e_68d65976b2088322b12340e41cd91e45