### PR TITLE
Broaden Supabase readonly cookie error detection

### DIFF
--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -12,12 +12,44 @@ function createCookieAdapter(cookieStore: CookieStore) {
       return cookieStore.get(name)?.value;
     },
     set(name: string, value: string, options: CookieOptions) {
-      cookieStore.set({ name, value, ...options });
+      try {
+        cookieStore.set({ name, value, ...options });
+      } catch (error) {
+        if (!isReadonlyRequestCookiesError(error)) {
+          throw error;
+        }
+      }
     },
     remove(name: string, options: CookieOptions) {
-      cookieStore.set({ name, value: '', ...options, expires: new Date(0) });
+      try {
+        cookieStore.set({
+          name,
+          value: '',
+          ...options,
+          expires: new Date(0),
+        });
+      } catch (error) {
+        if (!isReadonlyRequestCookiesError(error)) {
+          throw error;
+        }
+      }
     },
   };
+}
+
+function isReadonlyRequestCookiesError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const constructorName = error.constructor?.name;
+  if (constructorName === 'ReadonlyRequestCookiesError') {
+    return true;
+  }
+
+  return error.message.includes(
+    'Cookies can only be modified in a Server Action or Route Handler',
+  );
 }
 
 export function createSupabaseServerClient(cookieStore: CookieStore): SupabaseClient {


### PR DESCRIPTION
## Summary
- detect Next.js readonly cookie errors by constructor name or message text so server components no longer crash when cookies are immutable
- keep ignoring readonly mutations in server components while allowing writes where cookies are mutable

## Testing
- NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d65976b2088322b12340e41cd91e45