### PR TITLE
Handle missing Supabase configuration gracefully

### DIFF
--- a/web/src/app/(auth)/login/auth-forms.tsx
+++ b/web/src/app/(auth)/login/auth-forms.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo, useState } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
-import { INITIAL_STATE, signInAction, signUpAction } from './actions';
+import { signInAction, signUpAction } from './actions';
+import { INITIAL_STATE } from './state';
 import { ClientSubscriptionPlan, UserRole } from '@/lib/domain';
 
 type AuthFormsProps = {

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { AuthForms } from './auth-forms';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseServerClient, SupabaseConfigError } from '@/lib/supabase/server';
 
 export const metadata: Metadata = {
   title: 'Meblomat – Logowanie i rejestracja',
@@ -16,7 +16,37 @@ type LoginPageProps = {
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const cookieStore = await cookies();
-  const supabase = createSupabaseServerClient(cookieStore);
+  let supabase;
+
+  try {
+    supabase = createSupabaseServerClient(cookieStore);
+  } catch (error) {
+    if (error instanceof SupabaseConfigError) {
+      return (
+        <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 px-6 py-16 text-slate-100">
+          <div className="mx-auto w-full max-w-xl rounded-3xl border border-red-500/30 bg-red-500/10 p-8 text-center shadow-2xl shadow-black/50">
+            <span className="inline-flex rounded-full border border-red-400/40 bg-red-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-red-200">
+              Konfiguracja wymagana
+            </span>
+            <h1 className="mt-4 text-2xl font-semibold text-white md:text-3xl">Połącz aplikację z Supabase</h1>
+            <p className="mt-3 text-sm text-red-100/90">
+              Aby uruchomić logowanie i rejestrację, dodaj zmienne środowiskowe
+              <code className="mx-1 rounded bg-red-500/20 px-2 py-1 text-[0.8em]">NEXT_PUBLIC_SUPABASE_URL</code>
+              oraz
+              <code className="mx-1 rounded bg-red-500/20 px-2 py-1 text-[0.8em]">NEXT_PUBLIC_SUPABASE_ANON_KEY</code>
+              w ustawieniach projektu (np. plik
+              <code className="mx-1 rounded bg-red-500/20 px-2 py-1 text-[0.8em]">.env.local</code>
+              lub na serwerze Vercel).
+            </p>
+            <p className="mt-4 text-xs text-red-100/70">
+              Po zapisaniu zmian ponownie zbuduj aplikację. Instrukcje krok po kroku znajdziesz w dokumentacji Supabase.
+            </p>
+          </div>
+        </main>
+      );
+    }
+    throw error;
+  }
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/web/src/app/(auth)/login/state.ts
+++ b/web/src/app/(auth)/login/state.ts
@@ -1,0 +1,6 @@
+export type FormState = {
+  status: 'idle' | 'error' | 'success';
+  message?: string;
+};
+
+export const INITIAL_STATE: FormState = { status: 'idle' };

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -12,14 +12,44 @@ import {
 } from '@/lib/domain';
 import { formatCurrency, formatDateShort, formatPhone, formatRelativeDays } from '@/lib/format';
 import { getSiteUrl } from '@/lib/supabase/config';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseServerClient, SupabaseConfigError } from '@/lib/supabase/server';
 import { getDashboardData } from '@/server/dashboard';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const cookieStore = await cookies();
-  const supabase = createSupabaseServerClient(cookieStore);
+  let supabase;
+
+  try {
+    supabase = createSupabaseServerClient(cookieStore);
+  } catch (error) {
+    if (error instanceof SupabaseConfigError) {
+      return (
+        <main className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-slate-100">
+          <div className="w-full max-w-2xl rounded-3xl border border-red-500/30 bg-red-500/10 p-10 text-center shadow-2xl shadow-black/50">
+            <span className="inline-flex rounded-full border border-red-400/40 bg-red-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-red-200">
+              Konfiguracja Supabase wymagana
+            </span>
+            <h1 className="mt-4 text-3xl font-semibold text-white">Panel wymaga połączenia z Supabase</h1>
+            <p className="mt-3 text-sm text-red-100/90">
+              Uzupełnij zmienne środowiskowe
+              <code className="mx-1 rounded bg-red-500/20 px-2 py-1 text-[0.85em]">NEXT_PUBLIC_SUPABASE_URL</code>
+              oraz
+              <code className="mx-1 rounded bg-red-500/20 px-2 py-1 text-[0.85em]">NEXT_PUBLIC_SUPABASE_ANON_KEY</code>
+              w konfiguracji projektu. Dopiero wtedy logowanie użytkowników i dostęp do panelu będą działać poprawnie.
+            </p>
+            <p className="mt-4 text-xs text-red-100/70">
+              Dodaj wartości w pliku
+              <code className="mx-1 rounded bg-red-500/20 px-2 py-1 text-[0.85em]">.env.local</code>
+              lub w zmiennych środowiskowych serwera, a następnie ponownie uruchom wdrożenie.
+            </p>
+          </div>
+        </main>
+      );
+    }
+    throw error;
+  }
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/web/src/lib/supabase/client.ts
+++ b/web/src/lib/supabase/client.ts
@@ -1,12 +1,13 @@
 import { createBrowserClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
+import { requireSupabaseCredentials } from './config';
 
 let browserClient: SupabaseClient | undefined;
 
 export function getSupabaseBrowserClient(): SupabaseClient {
   if (!browserClient) {
-    browserClient = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    const { url, anonKey } = requireSupabaseCredentials();
+    browserClient = createBrowserClient(url, anonKey);
   }
   return browserClient;
 }

--- a/web/src/lib/supabase/config.ts
+++ b/web/src/lib/supabase/config.ts
@@ -1,16 +1,42 @@
-function readEnv(name: string) {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(
-      `Brak wymaganej zmiennej środowiskowej ${name}. Uzupełnij konfigurację Supabase w pliku .env.local.`,
-    );
+export class SupabaseConfigError extends Error {
+  constructor(
+    message =
+      'Brak konfiguracji Supabase. Dodaj zmienne NEXT_PUBLIC_SUPABASE_URL i NEXT_PUBLIC_SUPABASE_ANON_KEY w pliku .env.local lub w ustawieniach środowiska.',
+  ) {
+    super(message);
+    this.name = 'SupabaseConfigError';
   }
-  return value;
 }
 
-export const SUPABASE_URL = readEnv('NEXT_PUBLIC_SUPABASE_URL');
-export const SUPABASE_ANON_KEY = readEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+type SupabaseCredentials = {
+  url: string;
+  anonKey: string;
+};
+
 export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+export function getSupabaseCredentials(): SupabaseCredentials | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    return null;
+  }
+
+  return { url, anonKey };
+}
+
+export function requireSupabaseCredentials(): SupabaseCredentials {
+  const credentials = getSupabaseCredentials();
+  if (!credentials) {
+    throw new SupabaseConfigError();
+  }
+  return credentials;
+}
+
+export function isSupabaseConfigured(): boolean {
+  return getSupabaseCredentials() !== null;
+}
 
 export function getSiteUrl() {
   return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';

--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers';
 import type { CookieOptions } from '@supabase/ssr';
 import { createServerClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
+import { requireSupabaseCredentials } from './config';
 
 type CookieStore = Awaited<ReturnType<typeof cookies>>;
 
@@ -46,7 +46,10 @@ function isReadonlyRequestCookiesError(error: unknown): boolean {
 }
 
 export function createSupabaseServerClient(cookieStore: CookieStore): SupabaseClient {
-  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  const { url, anonKey } = requireSupabaseCredentials();
+  return createServerClient(url, anonKey, {
     cookies: createCookieAdapter(cookieStore),
   });
 }
+
+export { SupabaseConfigError } from './config';


### PR DESCRIPTION
## Summary
- add a reusable Supabase configuration helper that throws a descriptive error when required env vars are missing
- guard auth server actions, login page, and dashboard against missing Supabase credentials and show user-friendly instructions instead of crashing

## Testing
- npm run lint --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68d65f68a8148322834e710acab9b694