### PR TITLE
Handle Supabase configuration errors gracefully

### DIFF
--- a/web/src/lib/supabase/client.ts
+++ b/web/src/lib/supabase/client.ts
@@ -1,12 +1,13 @@
 import { createBrowserClient } from '@supabase/ssr';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { SUPABASE_ANON_KEY, SUPABASE_URL } from './config';
+import { requireSupabaseCredentials } from './config';
 
 let browserClient: SupabaseClient | undefined;
 
 export function getSupabaseBrowserClient(): SupabaseClient {
   if (!browserClient) {
-    browserClient = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    const { url, anonKey } = requireSupabaseCredentials();
+    browserClient = createBrowserClient(url, anonKey);
   }
   return browserClient;
 }

--- a/web/src/lib/supabase/config.ts
+++ b/web/src/lib/supabase/config.ts
@@ -1,15 +1,56 @@
+export class SupabaseConfigError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'SupabaseConfigError';
+  }
+}
+
 function readEnv(name: string) {
   const value = process.env[name];
-  if (!value) {
-    throw new Error(
+  if (!value?.trim()) {
+    throw new SupabaseConfigError(
       `Brak wymaganej zmiennej środowiskowej ${name}. Uzupełnij konfigurację Supabase w pliku .env.local.`,
     );
   }
-  return value;
+  return value.trim();
 }
 
-export const SUPABASE_URL = readEnv('NEXT_PUBLIC_SUPABASE_URL');
-export const SUPABASE_ANON_KEY = readEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+function validateSupabaseUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      throw new SupabaseConfigError(
+        'Nieprawidłowy protokół w zmiennej NEXT_PUBLIC_SUPABASE_URL. Użyj adresu rozpoczynającego się od https://.',
+      );
+    }
+    return url;
+  } catch (error) {
+    if (error instanceof SupabaseConfigError) {
+      throw error;
+    }
+    throw new SupabaseConfigError(
+      'Nieprawidłowy format zmiennej NEXT_PUBLIC_SUPABASE_URL. Skopiuj dokładny adres z zakładki API w Supabase.',
+    );
+  }
+}
+
+function validateSupabaseAnonKey(key: string) {
+  if (!key.includes('.')) {
+    throw new SupabaseConfigError(
+      'Nieprawidłowy format zmiennej NEXT_PUBLIC_SUPABASE_ANON_KEY. Skopiuj pełny klucz anonimowy JWT z panelu Supabase.',
+    );
+  }
+  return key;
+}
+
+export function requireSupabaseCredentials() {
+  const url = validateSupabaseUrl(readEnv('NEXT_PUBLIC_SUPABASE_URL'));
+  const anonKey = validateSupabaseAnonKey(readEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY'));
+  return { url, anonKey } as const;
+}
+
+export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+export const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 export function getSiteUrl() {


### PR DESCRIPTION
## Summary
- add a SupabaseConfigError helper that validates environment credentials and exposes requireSupabaseCredentials
- wrap Supabase server/browser client creation in validation with clearer error messages
- guard auth actions so configuration issues are logged and surface setup guidance in the UI

## Testing
- npm run lint --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68d6692bd6c08322add6555eeecbdca9