### PR TITLE
Add Supabase auth callback handler

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -19,6 +19,8 @@ SUPABASE_SERVICE_ROLE_KEY=...
 
 Po zmianie wartości uruchom `npm install` w katalogu `web/`, aby zainstalować zależności Supabase.
 
+> **Uwaga:** podczas wdrożeń na Vercelu ustaw zmienną `NEXT_PUBLIC_SITE_URL` na publiczny adres swojej aplikacji (np. `https://twoja-domena.vercel.app`). Supabase wykorzystuje tę wartość do generowania linków logowania, dlatego nieprawidłowy URL spowoduje, że użytkownik otrzyma błędny adres w wiadomości e-mail.
+
 ## Uruchamianie projektu
 
 ```bash

--- a/web/src/app/auth/callback/page.tsx
+++ b/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = getSupabaseBrowserClient();
+
+    supabase.auth
+      .exchangeCodeForSession(window.location.href)
+      .then(({ error }) => {
+        if (error) {
+          setError(error.message);
+          return;
+        }
+
+        router.replace('/');
+      })
+      .catch((err: unknown) => {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('Wystąpił nieoczekiwany błąd podczas logowania.');
+        }
+      });
+  }, [router]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-100">
+      <div className="rounded-lg bg-white px-6 py-8 text-center shadow-md">
+        <h1 className="text-xl font-semibold text-gray-900">
+          {error ? 'Logowanie nie powiodło się' : 'Logowanie w toku...'}
+        </h1>
+        <p className="mt-4 text-sm text-gray-600">
+          {error
+            ? `Spróbuj ponownie lub skontaktuj się z administratorem. Szczegóły: ${error}`
+            : 'Trwa kończenie procesu logowania. Za chwilę zostaniesz przekierowany.'}
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side auth callback page that exchanges the Supabase code and redirects after login
- document the need to configure NEXT_PUBLIC_SITE_URL in Vercel deployments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6710cbd74832290d38aa80fc2e5d6