### PR TITLE
Add gitattributes for shell scripts and document Windows clone tip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ przykładowe. Po wykonaniu migracji i uzupełnieniu tabel wystarczy
 odświeżyć stronę – dashboard automatycznie przełączy się na dane
 produkcyjne.
 
+> 💡 Jeśli klonujesz repozytorium po raz pierwszy na Windowsie,
+> rozważ uruchomienie polecenia `git config core.autocrlf false`, aby
+> uniknąć ponownej konwersji końcówek linii w plikach.
+
 ## Model danych
 
 | Model       | Kluczowe pola                              | Opis                                                 |


### PR DESCRIPTION
## Summary
- enforce LF line endings for shell scripts by configuring .gitattributes
- document Windows clone recommendation to disable automatic CRLF conversion in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6da2c9200832295fb204ab96b40d0