### PR TITLE
Add environment template and clarify setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Uzupełnij na podstawie connection stringa z panelu Supabase (Project Settings → Database).
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DATABASE?sslmode=require

--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ backendową.
    npm install
    npm install --prefix web
    ```
-2. Skopiuj plik `.env.example` do `.env` i uzupełnij zmienną
-   `DATABASE_URL` adresem połączeniowym z Supabase.
+2. Skopiuj plik `.env.example` do `.env` i uzupełnij zmienne
+   środowiskowe (w tym `DATABASE_URL`) danymi z zakładki **Project
+   Settings → Database** w panelu Supabase.
+   > 🪟 Użytkownicy Windows: ustaw `DATABASE_URL` w PowerShellu
+   > poleceniem `setx DATABASE_URL "postgresql://..."` lub skorzystaj z
+   > WSL, aby uniknąć problemów z migracjami.
 3. Wygeneruj klienta Prisma i utwórz tabele:
    ```bash
    npx prisma generate


### PR DESCRIPTION
## Summary
- add an example environment file with guidance on sourcing Supabase credentials
- expand the quick start instructions to reference the template and Supabase settings
- document a Windows-specific tip for defining the database URL to avoid migration issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6e3bb4a088322ba9700f518a4217a