### PR TITLE
Gracefully handle missing Supabase configuration

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -12,14 +12,56 @@ import {
 } from '@/lib/domain';
 import { formatCurrency, formatDateShort, formatPhone, formatRelativeDays } from '@/lib/format';
 import { getSiteUrl } from '@/lib/supabase/config';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { resolveSupabaseServerClient } from '@/lib/supabase/server';
 import { getDashboardData } from '@/server/dashboard';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const cookieStore = await cookies();
-  const supabase = createSupabaseServerClient(cookieStore);
+  const { client: supabase, error: supabaseError } = resolveSupabaseServerClient(cookieStore);
+
+  if (!supabase) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-slate-100">
+        <main className="mx-auto max-w-3xl px-6 py-16">
+          <div className="space-y-6 rounded-2xl border border-white/10 bg-white/5 p-8 text-sm text-slate-200 shadow shadow-black/30">
+            <div className="space-y-2">
+              <span className="inline-flex rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                Meblomat
+              </span>
+              <h1 className="text-2xl font-semibold text-white">Skonfiguruj połączenie z Supabase</h1>
+              <p className="text-slate-300">
+                {supabaseError ??
+                  'Aby korzystać z panelu, dodaj zmienne środowiskowe Supabase do pliku .env.local i uruchom ponownie aplikację.'}
+              </p>
+            </div>
+            <div className="space-y-2 rounded-xl border border-white/10 bg-slate-950/40 p-4">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Wymagane zmienne</p>
+              <ul className="list-disc space-y-1 pl-5 text-slate-200">
+                <li>
+                  <code className="rounded bg-slate-950/80 px-1">NEXT_PUBLIC_SUPABASE_URL</code> – adres URL projektu z zakładki API.
+                </li>
+                <li>
+                  <code className="rounded bg-slate-950/80 px-1">NEXT_PUBLIC_SUPABASE_ANON_KEY</code> – publiczny klucz anon.
+                </li>
+                <li>
+                  <code className="rounded bg-slate-950/80 px-1">SUPABASE_SERVICE_ROLE_KEY</code> – opcjonalny klucz serwisowy do funkcji serwerowych.
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-emerald-400/40 bg-emerald-500/10 p-4 text-emerald-100">
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-200">Podpowiedź</p>
+              <p className="mt-2">
+                Utwórz plik <code className="rounded bg-slate-950/80 px-1">web/.env.local</code>, wklej wartości zmiennych i zrestartuj komendę{' '}
+                <code className="rounded bg-slate-950/80 px-1">npm run web:dev</code>.
+              </p>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -58,3 +58,19 @@ export function createSupabaseServerClient(cookieStore: CookieStore): SupabaseCl
     );
   }
 }
+
+export function resolveSupabaseServerClient(cookieStore: CookieStore): {
+  client: SupabaseClient | null;
+  error: string | null;
+} {
+  try {
+    const client = createSupabaseServerClient(cookieStore);
+    return { client, error: null };
+  } catch (error) {
+    if (error instanceof SupabaseConfigError) {
+      console.warn('[Supabase] Pominięto inicjalizację klienta na serwerze:', error.message);
+      return { client: null, error: error.message };
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Supabase server client resolver that catches configuration errors and falls back gracefully
- render a configuration guide on the dashboard when Supabase credentials are missing to avoid server errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6ec1f09788322b584f1b6b81d478c