### PR TITLE
Enable RLS policies for carpentry tables

### DIFF
--- a/prisma/sql/20250926_init.sql
+++ b/prisma/sql/20250926_init.sql
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS "Workshop" (
 
     CONSTRAINT "Workshop_pkey" PRIMARY KEY ("id")
 );
+ALTER TABLE "Workshop" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "Carpenter" (
     "id" SERIAL NOT NULL,
@@ -87,6 +88,7 @@ CREATE TABLE IF NOT EXISTS "Carpenter" (
 
     CONSTRAINT "Carpenter_pkey" PRIMARY KEY ("id")
 );
+ALTER TABLE "Carpenter" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "Client" (
     "id" SERIAL NOT NULL,
@@ -101,6 +103,7 @@ CREATE TABLE IF NOT EXISTS "Client" (
 
     CONSTRAINT "Client_pkey" PRIMARY KEY ("id")
 );
+ALTER TABLE "Client" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "Order" (
     "id" SERIAL NOT NULL,
@@ -121,6 +124,7 @@ CREATE TABLE IF NOT EXISTS "Order" (
 
     CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
 );
+ALTER TABLE "Order" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "OrderTask" (
     "id" SERIAL NOT NULL,
@@ -135,6 +139,7 @@ CREATE TABLE IF NOT EXISTS "OrderTask" (
 
     CONSTRAINT "OrderTask_pkey" PRIMARY KEY ("id")
 );
+ALTER TABLE "OrderTask" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "OrderNote" (
     "id" SERIAL NOT NULL,
@@ -146,6 +151,7 @@ CREATE TABLE IF NOT EXISTS "OrderNote" (
 
     CONSTRAINT "OrderNote_pkey" PRIMARY KEY ("id")
 );
+ALTER TABLE "OrderNote" ENABLE ROW LEVEL SECURITY;
 
 -- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "Carpenter_email_key" ON "Carpenter"("email");
@@ -285,3 +291,48 @@ BEGIN
     END IF;
 END
 $$;
+
+-- Ensure authenticated users retain access when RLS is enabled.
+DO $$
+DECLARE
+    table_name TEXT;
+    policy_name TEXT;
+    schema_name TEXT := current_schema();
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'Workshop',
+        'Carpenter',
+        'Client',
+        'Order',
+        'OrderTask',
+        'OrderNote'
+    ]
+    LOOP
+        policy_name := table_name || '_authenticated_full_access';
+
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_policies
+            WHERE schemaname = schema_name
+              AND tablename = table_name
+              AND policyname = policy_name
+        ) THEN
+            EXECUTE format(
+                'CREATE POLICY %I ON %I.%I FOR ALL TO authenticated USING (true) WITH CHECK (true);',
+                policy_name,
+                schema_name,
+                table_name
+            );
+        END IF;
+    END LOOP;
+END
+$$;
+
+GRANT USAGE ON SCHEMA public TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO authenticated;


### PR DESCRIPTION
## Summary
- enable row level security on the Workshop, Carpenter, Client, Order, OrderTask, and OrderNote tables in the 20250926 init SQL
- add an idempotent helper loop to create authenticated full access policies for those tables when missing
- grant schema, table, and sequence privileges so the authenticated role retains CRUD capabilities with RLS enabled

## Testing
- npx supabase db lint *(fails: no local Postgres instance available)*

------
https://chatgpt.com/codex/tasks/task_e_68d80ca45ab8832295394ac8ed3bb870