### PR TITLE
Restrict client sign-up to the free plan

### DIFF
--- a/web/src/app/(auth)/login/actions.ts
+++ b/web/src/app/(auth)/login/actions.ts
@@ -113,7 +113,6 @@ export async function signUpAction(_: FormState, formData: FormData): Promise<Fo
     const email = normalizeString(formData.get('email'));
     const password = normalizeString(formData.get('password'));
     const role = normalizeString(formData.get('role'));
-    const clientPlan = normalizeString(formData.get('clientPlan'));
     const invitedBy = normalizeString(formData.get('invitedBy')) || undefined;
 
     if (!email || !password) {
@@ -138,12 +137,7 @@ export async function signUpAction(_: FormState, formData: FormData): Promise<Fo
     const metadata =
       role === UserRole.CARPENTER
         ? resolveCarpenterMetadata()
-        : resolveClientMetadata(
-            clientPlan === ClientSubscriptionPlan.PREMIUM
-              ? ClientSubscriptionPlan.PREMIUM
-              : ClientSubscriptionPlan.FREE,
-            invitedBy,
-          );
+        : resolveClientMetadata(ClientSubscriptionPlan.FREE, invitedBy);
 
     const { data, error } = await supabase.auth.signUp({
       email,

--- a/web/src/app/(auth)/login/auth-forms.tsx
+++ b/web/src/app/(auth)/login/auth-forms.tsx
@@ -8,7 +8,7 @@ import {
   signInWithGoogleAction,
   signUpAction,
 } from './actions';
-import { ClientSubscriptionPlan, UserRole } from '@/lib/domain';
+import { UserRole } from '@/lib/domain';
 
 type AuthFormsProps = {
   invitedBy?: string | null;
@@ -209,27 +209,9 @@ export function AuthForms({ invitedBy }: AuthFormsProps) {
                 <p className="mt-2 text-xs text-slate-300">
                   Darmowe konto do wysyłania zapytań ofertowych do maksymalnie 2 stolarzy.
                 </p>
-                <div className="mt-4 space-y-2 rounded-xl bg-slate-900/60 p-3">
-                  <label className="flex items-center justify-between text-xs text-slate-200">
-                    <span>Plan standardowy</span>
-                    <input
-                      type="radio"
-                      name="clientPlan"
-                      value={ClientSubscriptionPlan.FREE}
-                      defaultChecked
-                      className="h-3 w-3"
-                    />
-                  </label>
-                  <label className="flex items-center justify-between text-xs text-slate-200">
-                    <span>Plan premium (nielimitowane zapytania)</span>
-                    <input
-                      type="radio"
-                      name="clientPlan"
-                      value={ClientSubscriptionPlan.PREMIUM}
-                      className="h-3 w-3"
-                    />
-                  </label>
-                </div>
+                <p className="mt-1 text-xs text-slate-400">
+                  Po utworzeniu konta możesz przejść na plan Pro, aby znieść limit zapytań.
+                </p>
               </label>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the premium client option from the registration form and clarify that upgrades happen after account creation
- ensure the sign-up server action always provisions client accounts with the free plan

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d81dd19fc4832282b56a8c9d0782d5