### PR TITLE
Ensure order references default to UUID

### DIFF
--- a/prisma/migrations/20250926205656_init/migration.sql
+++ b/prisma/migrations/20250926205656_init/migration.sql
@@ -1,3 +1,6 @@
+-- Ensure pgcrypto extension for UUID generation
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
 -- CreateEnum
 CREATE TYPE "OrderStatus" AS ENUM ('PENDING', 'IN_PROGRESS', 'READY_FOR_DELIVERY', 'COMPLETED', 'CANCELLED');
 
@@ -54,7 +57,7 @@ CREATE TABLE "Client" (
 -- CreateTable
 CREATE TABLE "Order" (
     "id" SERIAL NOT NULL,
-    "reference" TEXT NOT NULL,
+    "reference" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
     "title" TEXT NOT NULL,
     "description" TEXT,
     "status" "OrderStatus" NOT NULL DEFAULT 'PENDING',

--- a/prisma/sql/20250926_init.sql
+++ b/prisma/sql/20250926_init.sql
@@ -1,5 +1,8 @@
 SET search_path = public;
 
+-- Ensure pgcrypto extension for UUID helpers
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
 -- CreateEnum
 DO $$
 BEGIN
@@ -107,7 +110,7 @@ ALTER TABLE "Client" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "Order" (
     "id" SERIAL NOT NULL,
-    "reference" TEXT NOT NULL,
+    "reference" TEXT NOT NULL DEFAULT gen_random_uuid()::text,
     "title" TEXT NOT NULL,
     "description" TEXT,
     "status" "OrderStatus" NOT NULL DEFAULT 'PENDING',
@@ -179,6 +182,10 @@ CREATE INDEX IF NOT EXISTS "Order_clientId_idx" ON "Order"("clientId");
 
 -- CreateIndex
 CREATE INDEX IF NOT EXISTS "OrderTask_orderId_status_idx" ON "OrderTask"("orderId", "status");
+
+-- Ensure default for order reference to maintain UUID auto-generation
+ALTER TABLE "Order"
+    ALTER COLUMN "reference" SET DEFAULT gen_random_uuid()::text;
 
 -- AddForeignKey
 DO $$


### PR DESCRIPTION
## Summary
- enable the pgcrypto extension in both the Prisma migration and Supabase bootstrap script so UUID helpers are available
- default the Order.reference column to `gen_random_uuid()` in migrations and bootstrap SQL to avoid missing identifiers
- add an idempotent ALTER TABLE step in the Supabase script to guarantee the default is applied on existing deployments

## Testing
- not run (SQL changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d823f6b0f48322b151c34c0b465bce