### PR TITLE
Handle Next.js readonly cookies error

### DIFF
--- a/web/src/lib/supabase/server.ts
+++ b/web/src/lib/supabase/server.ts
@@ -41,7 +41,8 @@ function isReadonlyRequestCookiesError(error: unknown): boolean {
   return (
     error instanceof Error &&
     (error.name === 'ReadonlyRequestCookiesError' ||
-      error.message.includes('ReadonlyRequestCookiesError'))
+      error.message.includes('ReadonlyRequestCookiesError') ||
+      error.message.includes('Cookies can only be modified in a Server Action or Route Handler'))
   );
 }
 


### PR DESCRIPTION
## Summary
- ensure Supabase server adapter ignores Next.js readonly cookies errors when mutation is blocked

## Testing
- npm run web:dev

------
https://chatgpt.com/codex/tasks/task_e_68d833265e6c8322ad97a2b4af635077