### PR TITLE
Ensure CopyField clears clipboard status timeout

### DIFF
--- a/web/src/components/copy-field.tsx
+++ b/web/src/components/copy-field.tsx
@@ -9,11 +9,11 @@ type CopyFieldProps = {
 
 export function CopyField({ label, value }: CopyFieldProps) {
   const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
-      if (timeoutRef.current !== undefined) {
+      if (timeoutRef.current !== null) {
         clearTimeout(timeoutRef.current);
       }
     };
@@ -23,12 +23,12 @@ export function CopyField({ label, value }: CopyFieldProps) {
     try {
       await navigator.clipboard.writeText(value);
       setCopied(true);
-      if (timeoutRef.current !== undefined) {
+      if (timeoutRef.current !== null) {
         clearTimeout(timeoutRef.current);
       }
-      timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         setCopied(false);
-        timeoutRef.current = undefined;
+        timeoutRef.current = null;
       }, 2000);
     } catch (error) {
       console.error('Failed to copy link', error);

--- a/web/src/components/copy-field.tsx
+++ b/web/src/components/copy-field.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type CopyFieldProps = {
   label: string;
@@ -9,12 +9,27 @@ type CopyFieldProps = {
 
 export function CopyField({ label, value }: CopyFieldProps) {
   const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   async function handleCopy() {
     try {
       await navigator.clipboard.writeText(value);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+        timeoutRef.current = undefined;
+      }, 2000);
     } catch (error) {
       console.error('Failed to copy link', error);
     }


### PR DESCRIPTION
## Summary
- store the CopyField timeout identifier in a ref so it can be reused
- clear any existing timeout before scheduling a new one when copying
- add an effect cleanup to clear the timeout on unmount

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d83b7b1768832288d979f43c69c8de