### PR TITLE
Fix Supabase email confirmation handling

### DIFF
--- a/web/src/app/auth/callback/page.tsx
+++ b/web/src/app/auth/callback/page.tsx
@@ -2,8 +2,17 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import type { EmailOtpType } from '@supabase/supabase-js';
 
 import { getSupabaseBrowserClient } from '@/lib/supabase/client';
+
+const SUPPORTED_EMAIL_OTP_TYPES: EmailOtpType[] = [
+  'signup',
+  'magiclink',
+  'recovery',
+  'email_change',
+  'invite',
+];
 
 export default function AuthCallbackPage() {
   const router = useRouter();
@@ -11,24 +20,64 @@ export default function AuthCallbackPage() {
 
   useEffect(() => {
     const supabase = getSupabaseBrowserClient();
+    const url = new URL(window.location.href);
+    const errorDescription =
+      url.searchParams.get('error_description') ?? url.searchParams.get('error');
 
-    supabase.auth
-      .exchangeCodeForSession(window.location.href)
-      .then(({ error }) => {
-        if (error) {
-          setError(error.message);
+    if (errorDescription) {
+      setError(errorDescription);
+      return;
+    }
+
+    const tokenHash = url.searchParams.get('token_hash');
+    const typeParam = url.searchParams.get('type');
+    const code = url.searchParams.get('code');
+
+    async function finalizeSession() {
+      try {
+        if (tokenHash && typeParam) {
+          if (!SUPPORTED_EMAIL_OTP_TYPES.includes(typeParam as EmailOtpType)) {
+            setError('Link aktywacyjny ma nieobsługiwany typ potwierdzenia.');
+            return;
+          }
+
+          const { error } = await supabase.auth.verifyOtp({
+            type: typeParam as EmailOtpType,
+            token_hash: tokenHash,
+          });
+
+          if (error) {
+            setError(error.message);
+            return;
+          }
+
+          router.replace('/');
           return;
         }
 
-        router.replace('/');
-      })
-      .catch((err: unknown) => {
+        if (code) {
+          const { error } = await supabase.auth.exchangeCodeForSession(url.toString());
+
+          if (error) {
+            setError(error.message);
+            return;
+          }
+
+          router.replace('/');
+          return;
+        }
+
+        setError('Brak tokenu uwierzytelniającego w adresie URL.');
+      } catch (err) {
         if (err instanceof Error) {
           setError(err.message);
         } else {
           setError('Wystąpił nieoczekiwany błąd podczas logowania.');
         }
-      });
+      }
+    }
+
+    finalizeSession();
   }, [router]);
 
   return (


### PR DESCRIPTION
## Summary
- handle Supabase email confirmation links by verifying OTP token hashes when present
- keep support for OAuth/PKCE callbacks and improve error reporting in the auth callback flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d842ee1b4883229086fdba0d8f2288