### PR TITLE
Ensure site URL is validated before Supabase email redirect

### DIFF
--- a/web/src/lib/supabase/config.ts
+++ b/web/src/lib/supabase/config.ts
@@ -53,6 +53,45 @@ export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 export const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 export const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
+const DEFAULT_SITE_URL = 'http://localhost:3000';
+
+function validateSiteUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      throw new SupabaseConfigError(
+        'Nieprawidłowy protokół w zmiennej NEXT_PUBLIC_SITE_URL. Użyj adresu rozpoczynającego się od https://.',
+      );
+    }
+    return url;
+  } catch (error) {
+    if (error instanceof SupabaseConfigError) {
+      throw error;
+    }
+    throw new SupabaseConfigError(
+      'Nieprawidłowy format zmiennej NEXT_PUBLIC_SITE_URL. Upewnij się, że zawiera pełny adres strony, np. https://twojadomena.pl.',
+    );
+  }
+}
+
+export function requireSiteUrl() {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!siteUrl) {
+    if (process.env.NODE_ENV && process.env.NODE_ENV !== 'development') {
+      throw new SupabaseConfigError(
+        'Brak wymaganej zmiennej NEXT_PUBLIC_SITE_URL. Skonfiguruj adres strony w pliku .env, aby dokończyć rejestrację użytkowników.',
+      );
+    }
+    return DEFAULT_SITE_URL;
+  }
+
+  return validateSiteUrl(siteUrl);
+}
+
 export function getSiteUrl() {
-  return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!siteUrl) {
+    return DEFAULT_SITE_URL;
+  }
+  return validateSiteUrl(siteUrl);
 }


### PR DESCRIPTION
## Summary
- add a reusable helper that validates NEXT_PUBLIC_SITE_URL and prevents silent fallbacks in production
- use the validated site URL when building the Supabase email redirect and surface configuration errors in the sign-up form

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d84834f01c8322b5ee119a8c7c8aaf