### PR TITLE
Remove Supabase-specific RLS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ warstwą backendową.
 
    Skrypt pomija już istniejące typy enum, indeksy i klucze obce, dzięki czemu można go bezpiecznie uruchamiać ponownie.
 
+   Domyślnie zachowuje standardowe uprawnienia PostgreSQL (bez dodatkowych ról Supabase), więc w razie potrzeby nadaj dostęp użytkownikom ręcznie.
+
 
 4. Uruchom lokalnie dashboard (w katalogu `web/`):
    ```bash

--- a/prisma/sql/20250926_init.sql
+++ b/prisma/sql/20250926_init.sql
@@ -92,7 +92,6 @@ CREATE TABLE IF NOT EXISTS "Workshop" (
 
     CONSTRAINT "Workshop_pkey" PRIMARY KEY ("id")
 );
-ALTER TABLE "Workshop" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "Carpenter" (
     "id" SERIAL NOT NULL,
@@ -109,7 +108,6 @@ CREATE TABLE IF NOT EXISTS "Carpenter" (
 
     CONSTRAINT "Carpenter_pkey" PRIMARY KEY ("id")
 );
-ALTER TABLE "Carpenter" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "Client" (
     "id" SERIAL NOT NULL,
@@ -124,7 +122,6 @@ CREATE TABLE IF NOT EXISTS "Client" (
 
     CONSTRAINT "Client_pkey" PRIMARY KEY ("id")
 );
-ALTER TABLE "Client" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "Order" (
     "id" SERIAL NOT NULL,
@@ -145,7 +142,6 @@ CREATE TABLE IF NOT EXISTS "Order" (
 
     CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
 );
-ALTER TABLE "Order" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "OrderTask" (
     "id" SERIAL NOT NULL,
@@ -160,7 +156,6 @@ CREATE TABLE IF NOT EXISTS "OrderTask" (
 
     CONSTRAINT "OrderTask_pkey" PRIMARY KEY ("id")
 );
-ALTER TABLE "OrderTask" ENABLE ROW LEVEL SECURITY;
 -- CreateTable
 CREATE TABLE IF NOT EXISTS "OrderNote" (
     "id" SERIAL NOT NULL,
@@ -172,7 +167,6 @@ CREATE TABLE IF NOT EXISTS "OrderNote" (
 
     CONSTRAINT "OrderNote_pkey" PRIMARY KEY ("id")
 );
-ALTER TABLE "OrderNote" ENABLE ROW LEVEL SECURITY;
 
 -- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "Carpenter_email_key" ON "Carpenter"("email");
@@ -317,47 +311,6 @@ BEGIN
 END
 $$;
 
--- Ensure authenticated users retain access when RLS is enabled.
-DO $$
-DECLARE
-    table_name TEXT;
-    policy_name TEXT;
-    schema_name TEXT := current_schema();
-BEGIN
-    FOREACH table_name IN ARRAY ARRAY[
-        'Workshop',
-        'Carpenter',
-        'Client',
-        'Order',
-        'OrderTask',
-        'OrderNote'
-    ]
-    LOOP
-        policy_name := table_name || '_authenticated_full_access';
-
-        IF NOT EXISTS (
-            SELECT 1
-            FROM pg_policies
-            WHERE schemaname = schema_name
-              AND tablename = table_name
-              AND policyname = policy_name
-        ) THEN
-            EXECUTE format(
-                'CREATE POLICY %I ON %I.%I FOR ALL TO authenticated USING (true) WITH CHECK (true);',
-                policy_name,
-                schema_name,
-                table_name
-            );
-        END IF;
-    END LOOP;
-END
-$$;
-
-GRANT USAGE ON SCHEMA public TO authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-    GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+-- Row level security and role-specific grants are not enabled here so that
+-- the default PostgreSQL permissions (owned by the role executing the script)
+-- remain in place. Adjust privileges as required for your deployment.

--- a/scripts/create_tables.sql
+++ b/scripts/create_tables.sql
@@ -1,11 +1,10 @@
 -- SQL script to create the core tables for the carpentry management system.
 -- The statements are compatible with PostgreSQL and mirror the Prisma schema
 -- located at prisma/schema.prisma.  They are written to be idempotent so the
--- script can be executed multiple times (for example in Supabase's SQL
--- editor) without raising duplicate object errors.
+-- script can be executed multiple times (for example via psql or your
+-- preferred SQL client) without raising duplicate object errors.
 
--- Ensure we are operating inside the public schema because Supabase executes
--- SQL with a restricted search_path for security reasons.
+-- Ensure we operate inside the public schema for predictable object names.
 SET search_path = public;
 
 -- Enable required extensions.
@@ -96,8 +95,6 @@ CREATE TRIGGER trg_workshops_updated_at
 BEFORE UPDATE ON public.workshops
 FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
-ALTER TABLE public.workshops ENABLE ROW LEVEL SECURITY;
-
 -- Carpenters table.
 CREATE TABLE IF NOT EXISTS public.carpenters (
   id SERIAL PRIMARY KEY,
@@ -125,8 +122,6 @@ CREATE TRIGGER trg_carpenters_updated_at
 BEFORE UPDATE ON public.carpenters
 FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
-ALTER TABLE public.carpenters ENABLE ROW LEVEL SECURITY;
-
 -- Clients table.
 CREATE TABLE IF NOT EXISTS public.clients (
   id SERIAL PRIMARY KEY,
@@ -145,8 +140,6 @@ DROP TRIGGER IF EXISTS trg_clients_updated_at ON public.clients;
 CREATE TRIGGER trg_clients_updated_at
 BEFORE UPDATE ON public.clients
 FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
-
-ALTER TABLE public.clients ENABLE ROW LEVEL SECURITY;
 
 -- Orders table.
 CREATE TABLE IF NOT EXISTS public.orders (
@@ -191,8 +184,6 @@ CREATE TRIGGER trg_orders_updated_at
 BEFORE UPDATE ON public.orders
 FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
-ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;
-
 -- Order tasks table.
 CREATE TABLE IF NOT EXISTS public.order_tasks (
   id SERIAL PRIMARY KEY,
@@ -223,8 +214,6 @@ CREATE TRIGGER trg_order_tasks_updated_at
 BEFORE UPDATE ON public.order_tasks
 FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
 
-ALTER TABLE public.order_tasks ENABLE ROW LEVEL SECURITY;
-
 -- Order notes table.
 CREATE TABLE IF NOT EXISTS public.order_notes (
   id SERIAL PRIMARY KEY,
@@ -239,48 +228,5 @@ CREATE TABLE IF NOT EXISTS public.order_notes (
     ON DELETE CASCADE
 );
 
-ALTER TABLE public.order_notes ENABLE ROW LEVEL SECURITY;
-
--- Ensure authenticated users can work with the tables when RLS is enabled.
-DO $$
-DECLARE
-  table_name TEXT;
-  policy_name TEXT;
-BEGIN
-  FOREACH table_name IN ARRAY ARRAY[
-    'workshops',
-    'carpenters',
-    'clients',
-    'orders',
-    'order_tasks',
-    'order_notes'
-  ]
-  LOOP
-    policy_name := table_name || '_authenticated_full_access';
-
-    IF NOT EXISTS (
-      SELECT 1 FROM pg_policies
-      WHERE schemaname = 'public'
-        AND tablename = table_name
-        AND policyname = policy_name
-    ) THEN
-      EXECUTE format(
-        'CREATE POLICY %I ON public.%I FOR ALL TO authenticated USING (true) WITH CHECK (true);',
-        policy_name,
-        table_name
-      );
-    END IF;
-  END LOOP;
-END
-$$;
-
--- Grant the authenticated role the required table and sequence privileges and
--- ensure future tables inherit those permissions.
-GRANT USAGE ON SCHEMA public TO authenticated;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+-- The default PostgreSQL privileges remain in place. Grant access to additional
+-- roles as required by your environment.


### PR DESCRIPTION
## Summary
- drop Supabase-specific RLS enabling and authenticated grants from the SQL schema scripts
- document that the scripts now rely on default PostgreSQL permissions for manual deployments

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d856238a548322a5840adab0dc632c