### PR TITLE
Enable RLS for auth tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ warstwą backendową.
 
    Skrypt pomija już istniejące typy enum, indeksy i klucze obce, dzięki czemu można go bezpiecznie uruchamiać ponownie.
 
-   Domyślnie zachowuje standardowe uprawnienia PostgreSQL (bez dodatkowych ról Supabase), więc w razie potrzeby nadaj dostęp użytkownikom ręcznie.
+   Po tej zmianie tabele `User`/`Session` (oraz odpowiadające im `public.users`/`public.sessions`) mają włączoną politykę RLS, która dopuszcza jedynie rolę `service_role` Supabase. Jeśli chcesz, aby inne role (np. `authenticated`/`anon` lub dedykowane role aplikacji) mogły czytać lub zapisywać dane logowania, dodaj własne polityki `CREATE POLICY` po wdrożeniu migracji.
 
 
 4. Utwórz konto administratora (wymagane do logowania):

--- a/prisma/migrations/20250927224205_enable_rls_auth_tables/migration.sql
+++ b/prisma/migrations/20250927224205_enable_rls_auth_tables/migration.sql
@@ -1,0 +1,41 @@
+-- Enable and enforce row level security on Prisma auth tables
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all_access_user" ON "User";
+CREATE POLICY "service_role_all_access_user"
+    ON "User"
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+ALTER TABLE "Session" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Session" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all_access_session" ON "Session";
+CREATE POLICY "service_role_all_access_session"
+    ON "Session"
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+-- Mirror the same protections on the lower-case public tables used by manual SQL scripts
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all_access_public_users ON public.users;
+CREATE POLICY service_role_all_access_public_users
+    ON public.users
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+ALTER TABLE public.sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all_access_public_sessions ON public.sessions;
+CREATE POLICY service_role_all_access_public_sessions
+    ON public.sessions
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');

--- a/prisma/sql/20250926_init.sql
+++ b/prisma/sql/20250926_init.sql
@@ -219,6 +219,47 @@ CREATE TABLE IF NOT EXISTS "Session" (
     CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
 );
 
+-- Enforce row level security so only trusted roles (e.g. Supabase service_role) can access auth tables
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all_access_user" ON "User";
+CREATE POLICY "service_role_all_access_user"
+    ON "User"
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+ALTER TABLE "Session" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Session" FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all_access_session" ON "Session";
+CREATE POLICY "service_role_all_access_session"
+    ON "Session"
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all_access_public_users ON public.users;
+CREATE POLICY service_role_all_access_public_users
+    ON public.users
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
+ALTER TABLE public.sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all_access_public_sessions ON public.sessions;
+CREATE POLICY service_role_all_access_public_sessions
+    ON public.sessions
+    FOR ALL
+    USING (auth.role() = 'service_role')
+    WITH CHECK (auth.role() = 'service_role');
+
 -- CreateIndex
 CREATE UNIQUE INDEX IF NOT EXISTS "Carpenter_email_key" ON "Carpenter"("email");
 

--- a/scripts/create_tables.sql
+++ b/scripts/create_tables.sql
@@ -199,6 +199,27 @@ CREATE TABLE IF NOT EXISTS public.sessions (
 CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON public.sessions (user_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON public.sessions (expires_at);
 
+-- Enforce row level security defaults that align with Supabase expectations.
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all_access_public_users ON public.users;
+CREATE POLICY service_role_all_access_public_users
+  ON public.users
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+ALTER TABLE public.sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all_access_public_sessions ON public.sessions;
+CREATE POLICY service_role_all_access_public_sessions
+  ON public.sessions
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
 -- Orders table.
 CREATE TABLE IF NOT EXISTS public.orders (
   id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add a Prisma migration that enforces row level security on the auth tables and restricts access to trusted roles
- mirror the same RLS configuration in the manual bootstrap SQL files and scripts
- document the new requirement for granting access to non-service roles in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d86806ca2083228e2eeca08c2e69ea